### PR TITLE
Set default for ADMIN_OIDC_ALLOW_HTTP to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [Unreleased]
+- Set default for ADMIN_OIDC_ALLOW_HTTP to false in README to prevent unsafe settings in production
+
 ## [4.0.1] - 2025-01-16
 - Fix doctrine/orm require 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ itkdev_openid_connect:
         # Optional: Specify leeway (seconds) to account for clock skew between provider and hosting
         #           Defaults to 10
         leeway: '%env(int:ADMIN_OIDC_LEEWAY)%'
-        # Optional: Allow http requests (used for mocking a IdP)
+        # Optional: Allow (non-secure) http requests (used for mocking a IdP). NOT RECOMMENDED FOR PRODUCTION.
         #           Defaults to false
         allow_http: '%env(bool:ADMIN_OIDC_ALLOW_HTTP)%'
     user:
@@ -96,7 +96,7 @@ ADMIN_OIDC_CLIENT_ID=ADMIN_APP_CLIENT_ID
 ADMIN_OIDC_CLIENT_SECRET=ADMIN_APP_CLIENT_SECRET
 ADMIN_OIDC_REDIRECT_URI=ADMIN_APP_REDIRECT_URI
 ADMIN_OIDC_LEEWAY=30
-ADMIN_OIDC_ALLOW_HTTP=true
+ADMIN_OIDC_ALLOW_HTTP=false
 
 # "user" open id connect configuration variables
 USER_OIDC_METADATA_URL=USER_APP_METADATA_URL


### PR DESCRIPTION
When following the readme i have seen that projets end up with this line in their `.env`file:
```
ADMIN_OIDC_ALLOW_HTTP=true
```
This makes the effective default unsafe for production. Having the option to allow HTTP for local use when developing is fine. But it should only be set in `.env.local`