### PR TITLE
Bump actions/checkout to v6 and improve Taskfile

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         prefer: [prefer-lowest, prefer-stable]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |

--- a/.github/workflows/github_build_release.yml
+++ b/.github/workflows/github_build_release.yml
@@ -16,7 +16,7 @@ jobs:
       APP_ENV: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create a release in GitHub
         run: gh release create ${{ github.ref_name }} --verify-tag --generate-notes

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Create docker network
         run: |

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -15,7 +15,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |
@@ -29,7 +29,7 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |
@@ -65,7 +65,7 @@ jobs:
             php: "8.5"
             prefer: prefer-stable
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -31,7 +31,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Create docker network
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped actions/checkout from v5 to v6 in all GitHub workflows
+- Renamed PHP_EXEC variable to PHP in Taskfile
+- Added lint:composer task to Taskfile
+- Improved test:coverage to enable XDEBUG_MODE and add text output
+- Fixed test:matrix:reset to include CI profile when removing volumes
+- Fixed test:run to remove stale composer.lock before updating dependencies
+
 ## [4.1.0] - 2026-03-20
 
 ### Added

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,8 +4,8 @@ version: "3"
 
 vars:
   DOCKER_COMPOSE: "docker compose"
-  PHP_EXEC: "{{.DOCKER_COMPOSE}} exec phpfpm"
-  COMPOSER: "{{.PHP_EXEC}} composer"
+  PHP: "{{.DOCKER_COMPOSE}} exec phpfpm"
+  COMPOSER: "{{.PHP}} composer"
 
 tasks:
   default:
@@ -74,7 +74,7 @@ tasks:
   composer:check:
     desc: Validate and audit composer
     cmds:
-      - "{{.PHP_EXEC}} composer validate --strict"
+      - "{{.PHP}} composer validate --strict"
       - "{{.COMPOSER}} normalize --dry-run"
       - "{{.COMPOSER}} audit"
 
@@ -84,18 +84,26 @@ tasks:
     desc: Run all linters
     cmds:
       - task: lint:php
+      - task: lint:composer
       - task: lint:markdown
       - task: lint:yaml
 
   lint:php:
     desc: Check PHP coding standards
     cmds:
-      - "{{.PHP_EXEC}} vendor/bin/php-cs-fixer fix --dry-run --diff"
+      - "{{.PHP}} vendor/bin/php-cs-fixer fix --dry-run --diff"
 
   lint:php:fix:
     desc: Fix PHP coding standards
     cmds:
-      - "{{.PHP_EXEC}} vendor/bin/php-cs-fixer fix"
+      - "{{.PHP}} vendor/bin/php-cs-fixer fix"
+
+  lint:composer:
+    desc: Validate and audit composer
+    cmds:
+      - "{{.PHP}} composer validate --strict"
+      - "{{.COMPOSER}} normalize --dry-run"
+      - "{{.COMPOSER}} audit"
 
   lint:markdown:
     desc: Lint markdown files
@@ -122,19 +130,19 @@ tasks:
   analyze:php:
     desc: Run PHPStan static analysis
     cmds:
-      - "{{.PHP_EXEC}} vendor/bin/phpstan"
+      - "{{.PHP}} vendor/bin/phpstan"
 
   # Testing
 
   test:
     desc: Run tests
     cmds:
-      - "{{.PHP_EXEC}} vendor/bin/phpunit"
+      - "{{.PHP}} vendor/bin/phpunit"
 
   test:coverage:
     desc: Run tests with coverage
     cmds:
-      - "{{.PHP_EXEC}} vendor/bin/phpunit --coverage-clover=coverage/unit.xml"
+      - "{{.DOCKER_COMPOSE}} exec -e XDEBUG_MODE=coverage phpfpm vendor/bin/phpunit --coverage-text --coverage-clover=coverage/unit.xml"
 
   test:run:
     desc: "Run tests for a PHP version and dependency set (e.g. task test:run PHP=8.4 DEPS=lowest)"
@@ -154,6 +162,7 @@ tasks:
               cp /app/vendor/.composer.lock /app/composer.lock
               composer install -q
             else
+              rm -f /app/composer.lock
               composer update -q --{{.PREFER}}
               cp /app/composer.lock /app/vendor/.composer.lock
             fi'
@@ -162,7 +171,7 @@ tasks:
   test:matrix:reset:
     desc: Remove cached vendor volumes to force a fresh dependency resolve
     cmds:
-      - "{{.DOCKER_COMPOSE}} down --volumes"
+      - "{{.DOCKER_COMPOSE}} --profile ci down --volumes"
 
   test:matrix:
     desc: Run tests across all PHP versions (mirrors CI matrix)


### PR DESCRIPTION
## Summary
- Bumped `actions/checkout` from v5 to v6 in all GitHub workflow files
- Renamed `PHP_EXEC` variable to `PHP` in Taskfile
- Added `lint:composer` task and improved `test:coverage`, `test:run`, and `test:matrix:reset`
- Updated CHANGELOG.md

## Test plan
- [ ] Verify CI workflows pass with actions/checkout@v6
- [ ] Run `task lint` and confirm lint:composer is included
- [ ] Run `task test:coverage` and confirm XDEBUG_MODE is set correctly
- [ ] Run `task test:matrix:reset` and confirm CI profile volumes are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)