### PR TITLE
Preserve $previous chain in exception wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   forwarded to the underlying Guzzle HTTP client used by league/oauth2-client.
   Closes the long-standing inability to bound HTTP requests to the IdP.
 
+### Fixed
+
+- Preserve original cause via `$previous` in `CliLoginHelper` and
+  `OpenIdLoginAuthenticator::validateClaims` exception wraps. Previously
+  the message was copied but the chain to the originating PSR cache or
+  upstream OIDC failure was lost, making logs harder to debug.
+
 ### Changed
 
 - Mapped LoginController failures to 404 (unknown provider) or 503

--- a/src/Security/OpenIdLoginAuthenticator.php
+++ b/src/Security/OpenIdLoginAuthenticator.php
@@ -72,7 +72,7 @@ abstract class OpenIdLoginAuthenticator extends AbstractAuthenticator implements
             // Authentication successful
         } catch (ItkOpenIdConnectException $exception) {
             // Handle failed authentication
-            throw new ValidationException($exception->getMessage());
+            throw new ValidationException($exception->getMessage(), previous: $exception);
         }
 
         /** @var array<string, string> $claimsArray */

--- a/src/Util/CliLoginHelper.php
+++ b/src/Util/CliLoginHelper.php
@@ -34,7 +34,7 @@ class CliLoginHelper
         try {
             $revCacheItem = $this->cache->getItem($encodedUsername);
         } catch (InvalidArgumentException $e) {
-            throw new CacheException($e->getMessage());
+            throw new CacheException($e->getMessage(), previous: $e);
         }
 
         if ($revCacheItem->isHit()) {
@@ -53,7 +53,7 @@ class CliLoginHelper
         try {
             $cacheItem = $this->cache->getItem($token);
         } catch (InvalidArgumentException $e) {
-            throw new CacheException($e->getMessage());
+            throw new CacheException($e->getMessage(), previous: $e);
         }
 
         $cacheItem->set($encodedUsername);
@@ -73,7 +73,7 @@ class CliLoginHelper
         try {
             $usernameItem = $this->cache->getItem($token);
         } catch (InvalidArgumentException $e) {
-            throw new CacheException($e->getMessage());
+            throw new CacheException($e->getMessage(), previous: $e);
         }
 
         if (!$usernameItem->isHit()) {
@@ -91,7 +91,7 @@ class CliLoginHelper
             $this->cache->deleteItem($token);
             $this->cache->deleteItem($username);
         } catch (InvalidArgumentException $e) {
-            throw new CacheException($e->getMessage());
+            throw new CacheException($e->getMessage(), previous: $e);
         }
 
         return $this->decodeKey($username);

--- a/tests/Security/OpenIdLoginAuthenticatorTest.php
+++ b/tests/Security/OpenIdLoginAuthenticatorTest.php
@@ -87,8 +87,9 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
     public function testValidateClaimsCodeDoesNotValidate(): void
     {
+        $cause = new ClaimsException('test message');
         $stubProvider = $this->createStub(OpenIdConfigurationProvider::class);
-        $stubProvider->method('validateIdToken')->willThrowException(new ClaimsException('test message'));
+        $stubProvider->method('validateIdToken')->willThrowException($cause);
         $this->stubProviderManager->method('getProvider')->willReturn($stubProvider);
 
         $request = $this->createStub(Request::class);
@@ -96,9 +97,15 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
         $this->setupStubSessionOnRequest($request);
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('test message');
-        $this->authenticator->authenticate($request);
+        try {
+            $this->authenticator->authenticate($request);
+        } catch (ValidationException $thrown) {
+            $this->assertSame('test message', $thrown->getMessage());
+            $this->assertSame($cause, $thrown->getPrevious(), 'Original cause must be chained');
+
+            return;
+        }
+        $this->fail('Expected ValidationException');
     }
 
     public function testValidateClaimsSuccess(): void

--- a/tests/Util/CliLoginHelperTest.php
+++ b/tests/Util/CliLoginHelperTest.php
@@ -83,16 +83,21 @@ class CliLoginHelperTest extends TestCase
 
     public function testCreateTokenThrowsCacheExceptionOnGetItem(): void
     {
+        $cause = new TestInvalidArgumentException('Cache error');
         $stubCache = $this->createStub(CacheItemPoolInterface::class);
-        $stubCache->method('getItem')
-            ->willThrowException(new TestInvalidArgumentException('Cache error'));
+        $stubCache->method('getItem')->willThrowException($cause);
 
         $cliHelper = new CliLoginHelper($stubCache);
 
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Cache error');
+        try {
+            $cliHelper->createToken('test_user');
+        } catch (CacheException $thrown) {
+            $this->assertSame('Cache error', $thrown->getMessage());
+            $this->assertSame($cause, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $cliHelper->createToken('test_user');
+            return;
+        }
+        $this->fail('Expected CacheException');
     }
 
     public function testCreateTokenThrowsCacheExceptionOnSecondGetItem(): void
@@ -101,38 +106,49 @@ class CliLoginHelperTest extends TestCase
         $stubCacheItem->method('isHit')->willReturn(false);
         $stubCacheItem->method('get')->willReturn(null);
 
+        $cause = new TestInvalidArgumentException('Second cache error');
         $stubCache = $this->createStub(CacheItemPoolInterface::class);
         $callCount = 0;
         $stubCache->method('getItem')
-            ->willReturnCallback(function () use ($stubCacheItem, &$callCount) {
+            ->willReturnCallback(function () use ($stubCacheItem, $cause, &$callCount) {
                 ++$callCount;
                 if (1 === $callCount) {
                     return $stubCacheItem;
                 }
-                throw new TestInvalidArgumentException('Second cache error');
+                throw $cause;
             });
         $stubCache->method('save')->willReturn(true);
 
         $cliHelper = new CliLoginHelper($stubCache);
 
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Second cache error');
+        try {
+            $cliHelper->createToken('another_user');
+        } catch (CacheException $thrown) {
+            $this->assertSame('Second cache error', $thrown->getMessage());
+            $this->assertSame($cause, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $cliHelper->createToken('another_user');
+            return;
+        }
+        $this->fail('Expected CacheException');
     }
 
     public function testGetUsernameThrowsCacheExceptionOnGetItem(): void
     {
+        $cause = new TestInvalidArgumentException('Cache error');
         $stubCache = $this->createStub(CacheItemPoolInterface::class);
-        $stubCache->method('getItem')
-            ->willThrowException(new TestInvalidArgumentException('Cache error'));
+        $stubCache->method('getItem')->willThrowException($cause);
 
         $cliHelper = new CliLoginHelper($stubCache);
 
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Cache error');
+        try {
+            $cliHelper->getUsername('some-token');
+        } catch (CacheException $thrown) {
+            $this->assertSame('Cache error', $thrown->getMessage());
+            $this->assertSame($cause, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $cliHelper->getUsername('some-token');
+            return;
+        }
+        $this->fail('Expected CacheException');
     }
 
     public function testCreateTokenThrowsCacheExceptionOnNonStringCachedToken(): void
@@ -175,16 +191,21 @@ class CliLoginHelperTest extends TestCase
         $stubCacheItem->method('isHit')->willReturn(true);
         $stubCacheItem->method('get')->willReturn('encoded_username');
 
+        $cause = new TestInvalidArgumentException('Delete error');
         $stubCache = $this->createStub(CacheItemPoolInterface::class);
         $stubCache->method('getItem')->willReturn($stubCacheItem);
-        $stubCache->method('deleteItem')
-            ->willThrowException(new TestInvalidArgumentException('Delete error'));
+        $stubCache->method('deleteItem')->willThrowException($cause);
 
         $cliHelper = new CliLoginHelper($stubCache);
 
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Delete error');
+        try {
+            $cliHelper->getUsername('some-token');
+        } catch (CacheException $thrown) {
+            $this->assertSame('Delete error', $thrown->getMessage());
+            $this->assertSame($cause, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $cliHelper->getUsername('some-token');
+            return;
+        }
+        $this->fail('Expected CacheException');
     }
 }


### PR DESCRIPTION
## Summary

Five sites in the bundle catch an upstream exception and rethrow as a bundle exception with the message copied — but the chain to the originating exception is dropped. This means error logs (and `$e->getPrevious()` traversal) lose the underlying PSR cache or upstream OIDC failure, making debug from a 500/503 response impossible to root-cause without reading the bundle source.

Fixed by adding `previous: $e` (named argument) to each `new CacheException(...)` / `new ValidationException(...)`. No public API change; concrete exception types and messages are unchanged.

### Sites fixed

| File | Site | Caught | Rethrown |
|---|---|---|---|
| `src/Util/CliLoginHelper.php` | `createToken` first `getItem` | PSR cache `InvalidArgumentException` | `CacheException` |
| `src/Util/CliLoginHelper.php` | `createToken` second `getItem` | PSR cache `InvalidArgumentException` | `CacheException` |
| `src/Util/CliLoginHelper.php` | `getUsername` `getItem` | PSR cache `InvalidArgumentException` | `CacheException` |
| `src/Util/CliLoginHelper.php` | `getUsername` `deleteItem` | PSR cache `InvalidArgumentException` | `CacheException` |
| `src/Security/OpenIdLoginAuthenticator.php` | `validateClaims` token validation | `ItkOpenIdConnectException` | `ValidationException` |

## Tests

Converted the five existing `expectException` + `expectExceptionMessage` tests to a `try`/`catch`/early-return pattern so each test now also asserts `getPrevious()` returns the original cause object (same pattern as PR #33). Test count (56) and coverage (100%) unchanged.

## Backward compatibility

Additive only. Consumers reading `$e->getMessage()` or catching the concrete exception types still behave the same. Consumers reading `$e->getPrevious()` now get the cause they previously got `null` for — a strict improvement.

## Test plan

- [x] `task test` — 56 tests, 141 assertions pass
- [x] `task analyze:php` — phpstan max, no errors
- [x] `task lint:php` — clean
- [ ] `task test:matrix` — pending in CI

## Context

Part of the larger exception-contract migration described in `EXCEPTION-CONTRACT-MIGRATION.md` (PR 0). Self-contained patch-level fix; does not depend on the upcoming 5.0 contract work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)