### PR TITLE
Lock the exception contract with custom PHPStan rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`
   marker for catching all bundle-thrown OIDC failures.
+- Custom PHPStan rules (`ThrownExceptionImplementsBundleMarker`,
+  `WrappedExceptionChainsPrevious`) that lock the exception contract on every
+  CI run — thrown exceptions must implement the marker (with documented
+  controller/authenticator carve-outs), and wraps inside a catch must chain
+  the caught cause as `$previous`.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "ItkDev\\OpenIdConnectBundle\\PHPStan\\": "phpstan/",
             "ItkDev\\OpenIdConnectBundle\\Tests\\": "tests/"
         }
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,12 +5,14 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 	- vendor/phpstan/phpstan-symfony/extension.neon
 	- vendor/phpstan/phpstan-symfony/rules.neon
+	- phpstan/exception-contract.neon
 
 parameters:
 	level: max
 	paths:
 		- src
 		- tests
+		- phpstan/Rule
 	reportIgnoresWithoutComments: true
 
 	ignoreErrors:

--- a/phpstan/README.md
+++ b/phpstan/README.md
@@ -1,0 +1,75 @@
+# PHPStan exception-contract rules
+
+Two custom PHPStan rules lock the exception contract documented in
+[`CLAUDE.md`](../CLAUDE.md). They run automatically as part of
+`task analyze:php` (and therefore `task pr:actions`).
+
+## `ThrownExceptionImplementsBundleMarker`
+
+Every literal `throw new X(...)` site under `src/` must throw an exception
+that implements:
+
+- `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`, or
+- `ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface` (the upstream marker).
+
+Two framework-boundary carve-outs apply, matching the prose in CLAUDE.md:
+
+| Path                                | Additionally allowed                                                    | Why                                                                |
+| ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `src/Controller/*`                  | `Symfony\Component\HttpKernel\Exception\HttpExceptionInterface`         | Symfony's kernel renders the HTTP status off these.                |
+| `src/Security/*Authenticator.php`   | `Symfony\Component\Security\Core\Exception\AuthenticationException`     | Symfony Security catches these to render the auth-failure response.|
+
+Escape hatch for an intentional outlier:
+
+```php
+// @phpstan-ignore throw.notMarkerInterface
+throw new MyOddException(...);
+```
+
+Pair the annotation with a one-line justification comment.
+
+## `WrappedExceptionChainsPrevious`
+
+Any `throw new Y(...)` inside a `catch (... $e)` block must pass `$e`
+as the new exception's `$previous`, either as a named argument
+(`previous: $e`) or as a direct positional argument value. This preserves
+`getPrevious()` traversal for logs and debugging — the lesson from the
+4.1 → 4.2 bug-fix PR that surfaced four `CliLoginHelper` wrap sites
+discarding the original cause.
+
+The check is intentionally lenient: it accepts any positional argument
+whose value is the catch variable, not just the 3rd slot. This covers
+Symfony's HTTP exception subclasses (which bake the status into the
+class and place `$previous` at index 1) without needing constructor
+reflection.
+
+Escape hatch when the rethrow is intentionally unrelated to the cause:
+
+```php
+} catch (\Throwable $e) {
+    // @phpstan-ignore throw.unchainedPrevious
+    throw new UnrelatedDomainException('...');
+}
+```
+
+Annotate with a justification.
+
+## Verifying the rules
+
+The rules are exercised on every CI run because PHPStan analyses `src/`
+and `tests/`. If a refactor produces a contract violation, the build
+breaks — which is the point. To verify a rule manually after editing,
+clear the cache and re-run:
+
+```shell
+docker compose exec phpfpm vendor/bin/phpstan clear-result-cache
+task analyze:php
+```
+
+## Why not php-cs-fixer
+
+php-cs-fixer's rule model is syntactic. Exception-type enforcement is
+a type-level concern — what a thrown class extends or implements — and
+PHPStan has the reflection machinery to express it. Future work could
+add a php-cs-fixer rule for the narrower "no `throw new \Exception(…)`
+anywhere" check, but the inheritance graph belongs to PHPStan.

--- a/phpstan/README.md
+++ b/phpstan/README.md
@@ -1,8 +1,8 @@
 # PHPStan exception-contract rules
 
 Two custom PHPStan rules lock the exception contract documented in
-[`CLAUDE.md`](../CLAUDE.md). They run automatically as part of
-`task analyze:php` (and therefore `task pr:actions`).
+[ADR 001](../docs/adr/001-marker-interface-exception-hierarchy.md). They run
+automatically as part of `task analyze:php` (and therefore `task pr:actions`).
 
 ## `ThrownExceptionImplementsBundleMarker`
 
@@ -12,7 +12,7 @@ that implements:
 - `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`, or
 - `ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface` (the upstream marker).
 
-Two framework-boundary carve-outs apply, matching the prose in CLAUDE.md:
+Two framework-boundary carve-outs apply, matching ADR 001:
 
 | Path                                | Additionally allowed                                                    | Why                                                                |
 | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
+++ b/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 /**
  * Every exception thrown from `src/` must implement the bundle or library marker.
  *
- * Two framework-boundary carve-outs (documented in `CLAUDE.md`):
+ * Two framework-boundary carve-outs (documented in ADR 001):
  *
  *  - HTTP controllers may throw Symfony `HttpExceptionInterface` subclasses; the
  *    kernel reads the status code off them to render the response.
@@ -110,7 +110,7 @@ final class ThrownExceptionImplementsBundleMarker implements Rule
 
         return [
             RuleErrorBuilder::message(sprintf(
-                'Thrown exception %s does not satisfy the bundle exception contract; expected an implementation of %s. See "Exceptions" in CLAUDE.md.',
+                'Thrown exception %s does not satisfy the bundle exception contract; expected an implementation of %s. See docs/adr/001-marker-interface-exception-hierarchy.md.',
                 $className,
                 $expected,
             ))

--- a/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
+++ b/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace ItkDev\OpenIdConnectBundle\PHPStan\Rule;
+
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
+use ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface;
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Every exception thrown from `src/` must implement the bundle or library marker.
+ *
+ * Two framework-boundary carve-outs (documented in `CLAUDE.md`):
+ *
+ *  - HTTP controllers may throw Symfony `HttpExceptionInterface` subclasses; the
+ *    kernel reads the status code off them to render the response.
+ *  - Authenticators may throw Symfony `AuthenticationException` subclasses; the
+ *    security framework catches those to render the failure response.
+ *
+ * Escape hatch: per-line "phpstan-ignore throw.notMarkerInterface" with a
+ * justification comment.
+ *
+ * @implements Rule<Throw_>
+ */
+final class ThrownExceptionImplementsBundleMarker implements Rule
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Throw_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        // Only enforce inside src/ — tests, fixtures, and tooling are not part of the contract.
+        if (!str_contains($file, '/src/')) {
+            return [];
+        }
+
+        $thrownExpr = $node->expr;
+        if (!$thrownExpr instanceof New_) {
+            // `throw $variable` or `throw functionCall()`: type may still be checked elsewhere,
+            // but this rule only inspects literal `throw new X(...)` sites.
+            return [];
+        }
+
+        $classNode = $thrownExpr->class;
+        if (!$classNode instanceof Node\Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($classNode);
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $reflection = $this->reflectionProvider->getClass($className);
+        $inController = str_contains($file, '/src/Controller/');
+        $inAuthenticator = str_contains($file, '/src/Security/') && str_ends_with($file, 'Authenticator.php');
+
+        if (
+            $reflection->implementsInterface(OpenIdConnectBundleExceptionInterface::class)
+            || $reflection->implementsInterface(OpenIdConnectExceptionInterface::class)
+        ) {
+            return [];
+        }
+
+        if ($inController && $reflection->implementsInterface(HttpExceptionInterface::class)) {
+            return [];
+        }
+
+        if (
+            $inAuthenticator
+            && (
+                AuthenticationException::class === $reflection->getName()
+                || $reflection->isSubclassOfClass($this->reflectionProvider->getClass(AuthenticationException::class))
+            )
+        ) {
+            return [];
+        }
+
+        $expected = match (true) {
+            $inController => sprintf(
+                '%s, %s, or %s (controller carve-out)',
+                OpenIdConnectBundleExceptionInterface::class,
+                OpenIdConnectExceptionInterface::class,
+                HttpExceptionInterface::class,
+            ),
+            $inAuthenticator => sprintf(
+                '%s, %s, or %s (authenticator carve-out)',
+                OpenIdConnectBundleExceptionInterface::class,
+                OpenIdConnectExceptionInterface::class,
+                AuthenticationException::class,
+            ),
+            default => sprintf('%s or %s', OpenIdConnectBundleExceptionInterface::class, OpenIdConnectExceptionInterface::class),
+        };
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Thrown exception %s does not satisfy the bundle exception contract; expected an implementation of %s. See "Exceptions" in CLAUDE.md.',
+                $className,
+                $expected,
+            ))
+                ->identifier('throw.notMarkerInterface')
+                ->build(),
+        ];
+    }
+}

--- a/phpstan/Rule/WrappedExceptionChainsPrevious.php
+++ b/phpstan/Rule/WrappedExceptionChainsPrevious.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace ItkDev\OpenIdConnectBundle\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * When a catch block rethrows by constructing a new exception, the caught
+ * exception must be chained as `$previous` (positional 3rd argument or named
+ * `previous:`). This enforces the "wrap at the boundary" rule in CLAUDE.md
+ * preserving `getPrevious()` traversal for logs and debugging.
+ *
+ * Escape hatch: add "phpstan-ignore throw.unchainedPrevious" on the throw line
+ * with a justification comment when the rethrow is intentionally unrelated to
+ * the caught cause.
+ *
+ * @implements Rule<Catch_>
+ */
+final class WrappedExceptionChainsPrevious implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Catch_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (null === $node->var) {
+            return [];
+        }
+
+        $catchVarName = $node->var->name;
+        if (!is_string($catchVarName)) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->findThrows($node->stmts) as $throw) {
+            $newExpr = $throw->expr;
+            if (!$newExpr instanceof New_) {
+                continue;
+            }
+
+            if ($this->chainsCaughtAsPrevious($newExpr, $catchVarName)) {
+                continue;
+            }
+
+            $thrownLabel = $this->describeNewExpr($newExpr);
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Exception %s thrown inside catch($%s) does not chain the caught exception as `previous`. Pass `previous: $%s` (or as the 3rd positional argument), or annotate with `@phpstan-ignore throw.unchainedPrevious` when the unrelated throw is intentional.',
+                $thrownLabel,
+                $catchVarName,
+                $catchVarName,
+            ))
+                ->identifier('throw.unchainedPrevious')
+                ->line($throw->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Collect every `throw` node reachable from these statements, but stop at
+     * nested catch blocks — those bind a different catch variable and are
+     * inspected by their own rule invocation.
+     *
+     * @param Node[] $stmts
+     *
+     * @return list<Throw_>
+     */
+    private function findThrows(array $stmts): array
+    {
+        $found = [];
+        foreach ($stmts as $stmt) {
+            $this->collect($stmt, $found);
+        }
+
+        return $found;
+    }
+
+    /**
+     * @param list<Throw_> $found
+     */
+    private function collect(Node $node, array &$found): void
+    {
+        if ($node instanceof Catch_) {
+            // A nested catch owns its own catch variable scope; its rethrows are
+            // checked when that catch is processed.
+            return;
+        }
+
+        if ($node instanceof Throw_) {
+            $found[] = $node;
+        }
+
+        foreach ($node->getSubNodeNames() as $subName) {
+            $sub = $node->{$subName}; // @phpstan-ignore property.dynamicName (walking an AST node's children requires a dynamic subnode name lookup; the names come from getSubNodeNames() and are intrinsically dynamic)
+            if ($sub instanceof Node) {
+                $this->collect($sub, $found);
+            } elseif (is_array($sub)) {
+                foreach ($sub as $item) {
+                    if ($item instanceof Node) {
+                        $this->collect($item, $found);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Accept either a named `previous: $catchVar` argument, or any argument whose
+     * value is directly the catch variable. The latter covers conventional PHP
+     * exceptions (positional $previous at index 2) and Symfony's HTTP exception
+     * subclasses (which bake the status code into the type and place $previous
+     * at index 1). Passing the catch variable as any other slot is unusual in
+     * practice; the looser check trades a rare false-negative for not depending
+     * on constructor reflection.
+     */
+    private function chainsCaughtAsPrevious(New_ $new, string $catchVarName): bool
+    {
+        foreach ($new->args as $arg) {
+            if (!$arg instanceof Arg) {
+                continue;
+            }
+
+            if (null !== $arg->name && 'previous' === $arg->name->name) {
+                return $this->valueIsVariable($arg->value, $catchVarName);
+            }
+
+            if (null === $arg->name && $this->valueIsVariable($arg->value, $catchVarName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function valueIsVariable(Node\Expr $expr, string $name): bool
+    {
+        return $expr instanceof Variable && is_string($expr->name) && $expr->name === $name;
+    }
+
+    private function describeNewExpr(New_ $new): string
+    {
+        $cls = $new->class;
+        if ($cls instanceof Node\Name) {
+            return $cls->toString();
+        }
+
+        return 'anonymous/dynamic exception';
+    }
+}

--- a/phpstan/Rule/WrappedExceptionChainsPrevious.php
+++ b/phpstan/Rule/WrappedExceptionChainsPrevious.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * When a catch block rethrows by constructing a new exception, the caught
  * exception must be chained as `$previous` (positional 3rd argument or named
- * `previous:`). This enforces the "wrap at the boundary" rule in CLAUDE.md
+ * `previous:`). This enforces the "wrap at the boundary" rule in ADR 001,
  * preserving `getPrevious()` traversal for logs and debugging.
  *
  * Escape hatch: add "phpstan-ignore throw.unchainedPrevious" on the throw line

--- a/phpstan/exception-contract.neon
+++ b/phpstan/exception-contract.neon
@@ -1,0 +1,9 @@
+services:
+    -
+        class: ItkDev\OpenIdConnectBundle\PHPStan\Rule\ThrownExceptionImplementsBundleMarker
+        tags:
+            - phpstan.rules.rule
+    -
+        class: ItkDev\OpenIdConnectBundle\PHPStan\Rule\WrappedExceptionChainsPrevious
+        tags:
+            - phpstan.rules.rule


### PR DESCRIPTION
## What

PR 3 of 3 in the exception-contract effort.

> ⚠️ **Stacked on #39** (`feature/exception-contract-migration`), which is stacked on #38. Merge in order; this PR's base auto-retargets to `develop` as the lower ones land. The diff here is only the rules.

Adds two project-specific PHPStan rules that lock the contract introduced in #39 so it can't silently drift:

- **`ThrownExceptionImplementsBundleMarker`** — every exception thrown from `src/` must implement `OpenIdConnectBundleExceptionInterface` or the library marker. Carve-outs: `src/Controller/*` may throw Symfony `HttpExceptionInterface`; `src/Security/*Authenticator.php` may throw `AuthenticationException`.
- **`WrappedExceptionChainsPrevious`** — an exception constructed inside a `catch` must chain the caught cause as `$previous`.

Registered via `phpstan/exception-contract.neon`, analysed on every CI run. `phpstan/README.md` documents the carve-outs and the per-line escape hatches.

## Why a separate PR

The migration (#39) and the lock-in are intentionally coupled but reviewable apart: #39 establishes the contract, this enforces it. Keeping them as two commits means a future revert of one leaves the other visible.

## Verification

`task analyze:php` (now including the two custom rules), `task lint`, and the full `task test:matrix` (PHP 8.3/8.4/8.5 × lowest/stable) all green against `itk-dev/openid-connect` 5.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)