### PR TITLE
release: 5.0.0

### DIFF
--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -80,4 +80,5 @@ jobs:
           docker network create frontend
 
       - run: |
+          docker compose run --rm phpfpm composer install
           docker compose run --rm phpfpm composer audit

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ var
 .php-cs-fixer.cache
 .phpunit.cache
 unit.xml
+
+# Local Claude Code instructions (not part of the published package)
+/CLAUDE.md

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -10,3 +10,5 @@ web/*.md
 web/core/
 web/libraries/
 web/*/contrib/
+# Claude Code guidance — verbose narrative prose, intentionally long lines.
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Hardened static analysis. PHPStan now analyses `tests/` in addition to
+  `src/`, runs the strict, deprecation, PHPUnit and Symfony rule packs, and
+  requires a comment on every ignore (`reportIgnoresWithoutComments`). Pinned
+  `phpstan/phpstan` to `^2.1.41`. No public-API or behavioural change.
+
+### Fixed
+
+- Tests build real `Request` instances instead of stubbing `Request`, which
+  fails under Symfony 8.1 (where `InputBag` is `final`) with recent PHPUnit.
+
 ## [4.2.0] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`
   marker for catching all bundle-thrown OIDC failures.
+- Custom PHPStan rules (`ThrownExceptionImplementsBundleMarker`,
+  `WrappedExceptionChainsPrevious`) that lock the exception contract on every
+  CI run — thrown exceptions must implement the marker (with documented
+  controller/authenticator carve-outs), and wraps inside a catch must chain
+  the caught cause as `$previous`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-06-02
+
 ### Changed (BREAKING)
 
 - **Exception hierarchy reworked.** Every exception thrown from a public
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CI run — thrown exceptions must implement the marker (with documented
   controller/authenticator carve-outs), and wraps inside a catch must chain
   the caught cause as `$previous`.
+- `UPGRADE-5.0.md` migration guide for consumers.
 
 ### Changed
 
@@ -204,7 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `itk-dev/openid-connect` 1.0.0 to 2.1.0
 - OpenId Connect Bundle: Added CLI login feature.
 
-[unreleased]: https://github.com/itk-dev/openid-connect-bundle/compare/4.2.0...HEAD
+[unreleased]: https://github.com/itk-dev/openid-connect-bundle/compare/5.0.0...HEAD
+[5.0.0]: https://github.com/itk-dev/openid-connect-bundle/compare/4.2.0...5.0.0
 [4.2.0]: https://github.com/itk-dev/openid-connect-bundle/compare/4.1.0...4.2.0
 [4.1.0]: https://github.com/itk-dev/openid-connect-bundle/compare/4.0.1...4.1.0
 [4.0.1]: https://github.com/itk-dev/openid-connect-bundle/compare/4.0.0...4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **Exception hierarchy reworked.** Every exception thrown from a public
+  method now implements `OpenIdConnectBundleExceptionInterface` (which
+  extends `\ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface`
+  from the upstream library). Concrete exceptions now extend the SPL type
+  that best describes the failure category (`\RuntimeException`,
+  `\InvalidArgumentException`); they no longer extend
+  `ItkOpenIdConnectBundleException`. Consumers catching the abstract base
+  must migrate to `OpenIdConnectBundleExceptionInterface` — the abstract
+  class is kept for this release as a documented alias and is
+  `@deprecated`, but `catch (ItkOpenIdConnectBundleException $e)` blocks
+  will no longer match any concrete thrown by the bundle.
+- Bumped `itk-dev/openid-connect` requirement to `^5.0` for the matching
+  upstream contract.
+- `OpenIdLoginAuthenticator::validateClaims` now catches on the marker
+  interface (`OpenIdConnectExceptionInterface`) instead of the deprecated
+  upstream abstract. The `$previous`-chain behaviour is preserved.
+- `LoginController::login` catches on the marker interface before mapping
+  to `ServiceUnavailableHttpException`. No consumer-visible behaviour
+  change.
+
+### Added
+
+- `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`
+  marker for catching all bundle-thrown OIDC failures.
+
 ### Changed
 
 - Hardened static analysis. PHPStan now analyses `tests/` in addition to
   `src/`, runs the strict, deprecation, PHPUnit and Symfony rule packs, and
   requires a comment on every ignore (`reportIgnoresWithoutComments`). Pinned
   `phpstan/phpstan` to `^2.1.41`. No public-API or behavioural change.
+
+### Deprecated
+
+- `ItkDev\OpenIdConnectBundle\Exception\ItkOpenIdConnectBundleException`
+  abstract class (catch `OpenIdConnectBundleExceptionInterface` instead).
+  Will be removed in 6.0.
 
 ### Fixed
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,0 +1,78 @@
+# Upgrading from 4.x to 5.0
+
+5.0 reworks the bundle's exception hierarchy onto a marker interface and
+bumps the `itk-dev/openid-connect` requirement to `^5.0`. Runtime behaviour
+is unchanged — this document covers the consumer-visible API changes you'll
+need to adjust catch blocks for.
+
+See the architecture decision in
+[docs/adr/001-marker-interface-exception-hierarchy.md](docs/adr/001-marker-interface-exception-hierarchy.md).
+
+## Catch the marker interface, not the abstract
+
+Concrete bundle exceptions no longer extend
+`\ItkDev\OpenIdConnectBundle\Exception\ItkOpenIdConnectBundleException`.
+Existing catches against the abstract will not match anything thrown by
+5.0+ code:
+
+```diff
+- } catch (\ItkDev\OpenIdConnectBundle\Exception\ItkOpenIdConnectBundleException $e) {
++ } catch (\ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface $e) {
+```
+
+The abstract class is kept through the 5.x line as a `@deprecated` alias
+that still implements the marker; removal is scheduled for 6.0.
+
+`OpenIdConnectBundleExceptionInterface` **extends** the upstream library's
+`\ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface`, so a
+single catch handles failures from both packages:
+
+```php
+try {
+    $claims = $this->validateClaims($request);
+} catch (\ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface $e) {
+    // catches both library- and bundle-thrown OIDC failures
+}
+```
+
+## Catch on SPL types still works
+
+Each concrete now extends the SPL type that best fits its failure category,
+so catches at the SPL level continue to match:
+
+| Concrete | Parent | When it fires |
+| --- | --- | --- |
+| `InvalidProviderException` | `\InvalidArgumentException` | Unknown provider key requested from the manager |
+| `UsernameDoesNotExistException` | `\InvalidArgumentException` | CLI login resolved a token to no username |
+| `CacheException` | `\RuntimeException` | PSR-6 cache layer failed during CLI login token handling |
+| `TokenNotFoundException` | `\RuntimeException` | CLI login token not found in the cache |
+| `UserDoesNotExistException` | `\RuntimeException` | Configured user provider has no matching user |
+
+For example, code catching the raw `\InvalidArgumentException` around a
+provider lookup keeps working, because `InvalidProviderException` still
+extends it:
+
+```php
+try {
+    $provider = $providerManager->getProvider($key);
+} catch (\InvalidArgumentException $e) { // still catches in 5.0
+    // ...
+}
+```
+
+## Update the dependency constraint
+
+If your application pins the bundle, bump it to `^5.0`. The bundle now
+requires `itk-dev/openid-connect:^5.0`; review that library's
+[UPGRADE-5.0.md](https://github.com/itk-dev/openid-connect/blob/main/UPGRADE-5.0.md)
+for its own contract changes (it reworks the same exception hierarchy and
+tightens several IdP-payload validations).
+
+## Framework-boundary exceptions are unchanged
+
+`LoginController` still ships Symfony `HttpException` subclasses
+(`NotFoundHttpException` for an unknown provider → 404,
+`ServiceUnavailableHttpException` for an unreachable IdP / cache failure →
+503), and authenticators still throw `AuthenticationException`. These are a
+documented carve-out from the wrap-at-boundary rule and did not change in
+5.0; the OIDC cause remains chained via `$previous`.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "doctrine/orm": "^2.8 || ^3.0",
-        "itk-dev/openid-connect": "^4.0",
+        "itk-dev/openid-connect": "^5.0",
         "symfony/cache": "^6.4 || ^7.0 || ^8.0",
         "symfony/framework-bundle": "^6.4.13 || ^7.0 || ^8.0",
         "symfony/security-bundle": "^6.4.13 || ^7.0 || ^8.0",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "ItkDev\\OpenIdConnectBundle\\PHPStan\\": "phpstan/",
             "ItkDev\\OpenIdConnectBundle\\Tests\\": "tests/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
     "require-dev": {
         "ergebnis/composer-normalize": "^2.28",
         "friendsofphp/php-cs-fixer": "^3.11",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.1.41",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^12.0",
         "rector/rector": "^2.0",
         "symfony/runtime": "^6.4.13 || ^7.0 || ^8.0"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,63 @@
+includes:
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- vendor/phpstan/phpstan-phpunit/extension.neon
+	- vendor/phpstan/phpstan-phpunit/rules.neon
+	- vendor/phpstan/phpstan-symfony/extension.neon
+	- vendor/phpstan/phpstan-symfony/rules.neon
+
 parameters:
 	level: max
 	paths:
 		- src
+		- tests
+	reportIgnoresWithoutComments: true
+
+	ignoreErrors:
+		# PHPUnit declares assertions as static methods on `Assert`, but the
+		# pervasive idiom is `$this->assertX()`. phpstan-phpunit handles type
+		# narrowing for these but doesn't override strict-rules' judgment that
+		# this is a dynamic call to a static method.
+		-
+			identifier: staticMethod.dynamicCall
+			path: tests/*
+
+		# Test fixture/helper PHPDoc completeness — out of scope for the static
+		# analysis hardening; can be tightened as a follow-up.
+		-
+			identifier: missingType.generics
+			path: tests/*
+		-
+			identifier: missingType.iterableValue
+			path: tests/*
+		-
+			identifier: missingType.return
+			path: tests/*
+
+		# Symfony's Processor returns an untyped array; phpstan-symfony narrows
+		# many other Symfony APIs but does not type processConfiguration's result
+		# from a Configuration definition. The tests probe specific keys precisely
+		# *because* the production code does.
+		-
+			identifier: argument.type
+			path: tests/DependencyInjection/ConfigurationTest.php
+		-
+			identifier: offsetAccess.nonOffsetAccessible
+			path: tests/DependencyInjection/ConfigurationTest.php
+
+		# `validateClaims` throws `ValidationException`, but the throw happens behind
+		# the abstract `authenticate()` the test fixture overrides, so PHPStan's
+		# throw-type analysis can't see it reach the catch. The test deliberately
+		# asserts the wrap behaviour by catching the concrete type.
+		-
+			identifier: catch.neverThrown
+			path: tests/Security/OpenIdLoginAuthenticatorTest.php
+
+		# Manager tests assert `getProvider()` returns an `OpenIdConfigurationProvider`
+		# as a "didn't throw on construction" smoke check. The return type already
+		# guarantees the class, so phpstan-phpunit flags the assertion as redundant.
+		# A follow-up should replace these with behavioural assertions on the
+		# constructed provider; until then the assertion documents intent.
+		-
+			identifier: method.alreadyNarrowedType
+			path: tests/Security/OpenIdConfigurationProviderManagerTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,12 +5,14 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 	- vendor/phpstan/phpstan-symfony/extension.neon
 	- vendor/phpstan/phpstan-symfony/rules.neon
+	- phpstan/exception-contract.neon
 
 parameters:
 	level: max
 	paths:
 		- src
 		- tests
+		- phpstan/Rule
 	reportIgnoresWithoutComments: true
 
 	ignoreErrors:

--- a/phpstan/README.md
+++ b/phpstan/README.md
@@ -1,0 +1,75 @@
+# PHPStan exception-contract rules
+
+Two custom PHPStan rules lock the exception contract documented in
+[`CLAUDE.md`](../CLAUDE.md). They run automatically as part of
+`task analyze:php` (and therefore `task pr:actions`).
+
+## `ThrownExceptionImplementsBundleMarker`
+
+Every literal `throw new X(...)` site under `src/` must throw an exception
+that implements:
+
+- `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`, or
+- `ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface` (the upstream marker).
+
+Two framework-boundary carve-outs apply, matching the prose in CLAUDE.md:
+
+| Path                                | Additionally allowed                                                    | Why                                                                |
+| ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `src/Controller/*`                  | `Symfony\Component\HttpKernel\Exception\HttpExceptionInterface`         | Symfony's kernel renders the HTTP status off these.                |
+| `src/Security/*Authenticator.php`   | `Symfony\Component\Security\Core\Exception\AuthenticationException`     | Symfony Security catches these to render the auth-failure response.|
+
+Escape hatch for an intentional outlier:
+
+```php
+// @phpstan-ignore throw.notMarkerInterface
+throw new MyOddException(...);
+```
+
+Pair the annotation with a one-line justification comment.
+
+## `WrappedExceptionChainsPrevious`
+
+Any `throw new Y(...)` inside a `catch (... $e)` block must pass `$e`
+as the new exception's `$previous`, either as a named argument
+(`previous: $e`) or as a direct positional argument value. This preserves
+`getPrevious()` traversal for logs and debugging — the lesson from the
+4.1 → 4.2 bug-fix PR that surfaced four `CliLoginHelper` wrap sites
+discarding the original cause.
+
+The check is intentionally lenient: it accepts any positional argument
+whose value is the catch variable, not just the 3rd slot. This covers
+Symfony's HTTP exception subclasses (which bake the status into the
+class and place `$previous` at index 1) without needing constructor
+reflection.
+
+Escape hatch when the rethrow is intentionally unrelated to the cause:
+
+```php
+} catch (\Throwable $e) {
+    // @phpstan-ignore throw.unchainedPrevious
+    throw new UnrelatedDomainException('...');
+}
+```
+
+Annotate with a justification.
+
+## Verifying the rules
+
+The rules are exercised on every CI run because PHPStan analyses `src/`
+and `tests/`. If a refactor produces a contract violation, the build
+breaks — which is the point. To verify a rule manually after editing,
+clear the cache and re-run:
+
+```shell
+docker compose exec phpfpm vendor/bin/phpstan clear-result-cache
+task analyze:php
+```
+
+## Why not php-cs-fixer
+
+php-cs-fixer's rule model is syntactic. Exception-type enforcement is
+a type-level concern — what a thrown class extends or implements — and
+PHPStan has the reflection machinery to express it. Future work could
+add a php-cs-fixer rule for the narrower "no `throw new \Exception(…)`
+anywhere" check, but the inheritance graph belongs to PHPStan.

--- a/phpstan/README.md
+++ b/phpstan/README.md
@@ -1,8 +1,8 @@
 # PHPStan exception-contract rules
 
 Two custom PHPStan rules lock the exception contract documented in
-[`CLAUDE.md`](../CLAUDE.md). They run automatically as part of
-`task analyze:php` (and therefore `task pr:actions`).
+[ADR 001](../docs/adr/001-marker-interface-exception-hierarchy.md). They run
+automatically as part of `task analyze:php` (and therefore `task pr:actions`).
 
 ## `ThrownExceptionImplementsBundleMarker`
 
@@ -12,7 +12,7 @@ that implements:
 - `ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface`, or
 - `ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface` (the upstream marker).
 
-Two framework-boundary carve-outs apply, matching the prose in CLAUDE.md:
+Two framework-boundary carve-outs apply, matching ADR 001:
 
 | Path                                | Additionally allowed                                                    | Why                                                                |
 | ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |

--- a/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
+++ b/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 /**
  * Every exception thrown from `src/` must implement the bundle or library marker.
  *
- * Two framework-boundary carve-outs (documented in `CLAUDE.md`):
+ * Two framework-boundary carve-outs (documented in ADR 001):
  *
  *  - HTTP controllers may throw Symfony `HttpExceptionInterface` subclasses; the
  *    kernel reads the status code off them to render the response.
@@ -110,7 +110,7 @@ final class ThrownExceptionImplementsBundleMarker implements Rule
 
         return [
             RuleErrorBuilder::message(sprintf(
-                'Thrown exception %s does not satisfy the bundle exception contract; expected an implementation of %s. See "Exceptions" in CLAUDE.md.',
+                'Thrown exception %s does not satisfy the bundle exception contract; expected an implementation of %s. See docs/adr/001-marker-interface-exception-hierarchy.md.',
                 $className,
                 $expected,
             ))

--- a/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
+++ b/phpstan/Rule/ThrownExceptionImplementsBundleMarker.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace ItkDev\OpenIdConnectBundle\PHPStan\Rule;
+
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
+use ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface;
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Every exception thrown from `src/` must implement the bundle or library marker.
+ *
+ * Two framework-boundary carve-outs (documented in `CLAUDE.md`):
+ *
+ *  - HTTP controllers may throw Symfony `HttpExceptionInterface` subclasses; the
+ *    kernel reads the status code off them to render the response.
+ *  - Authenticators may throw Symfony `AuthenticationException` subclasses; the
+ *    security framework catches those to render the failure response.
+ *
+ * Escape hatch: per-line "phpstan-ignore throw.notMarkerInterface" with a
+ * justification comment.
+ *
+ * @implements Rule<Throw_>
+ */
+final class ThrownExceptionImplementsBundleMarker implements Rule
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Throw_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        // Only enforce inside src/ — tests, fixtures, and tooling are not part of the contract.
+        if (!str_contains($file, '/src/')) {
+            return [];
+        }
+
+        $thrownExpr = $node->expr;
+        if (!$thrownExpr instanceof New_) {
+            // `throw $variable` or `throw functionCall()`: type may still be checked elsewhere,
+            // but this rule only inspects literal `throw new X(...)` sites.
+            return [];
+        }
+
+        $classNode = $thrownExpr->class;
+        if (!$classNode instanceof Node\Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($classNode);
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $reflection = $this->reflectionProvider->getClass($className);
+        $inController = str_contains($file, '/src/Controller/');
+        $inAuthenticator = str_contains($file, '/src/Security/') && str_ends_with($file, 'Authenticator.php');
+
+        if (
+            $reflection->implementsInterface(OpenIdConnectBundleExceptionInterface::class)
+            || $reflection->implementsInterface(OpenIdConnectExceptionInterface::class)
+        ) {
+            return [];
+        }
+
+        if ($inController && $reflection->implementsInterface(HttpExceptionInterface::class)) {
+            return [];
+        }
+
+        if (
+            $inAuthenticator
+            && (
+                AuthenticationException::class === $reflection->getName()
+                || $reflection->isSubclassOfClass($this->reflectionProvider->getClass(AuthenticationException::class))
+            )
+        ) {
+            return [];
+        }
+
+        $expected = match (true) {
+            $inController => sprintf(
+                '%s, %s, or %s (controller carve-out)',
+                OpenIdConnectBundleExceptionInterface::class,
+                OpenIdConnectExceptionInterface::class,
+                HttpExceptionInterface::class,
+            ),
+            $inAuthenticator => sprintf(
+                '%s, %s, or %s (authenticator carve-out)',
+                OpenIdConnectBundleExceptionInterface::class,
+                OpenIdConnectExceptionInterface::class,
+                AuthenticationException::class,
+            ),
+            default => sprintf('%s or %s', OpenIdConnectBundleExceptionInterface::class, OpenIdConnectExceptionInterface::class),
+        };
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Thrown exception %s does not satisfy the bundle exception contract; expected an implementation of %s. See "Exceptions" in CLAUDE.md.',
+                $className,
+                $expected,
+            ))
+                ->identifier('throw.notMarkerInterface')
+                ->build(),
+        ];
+    }
+}

--- a/phpstan/Rule/WrappedExceptionChainsPrevious.php
+++ b/phpstan/Rule/WrappedExceptionChainsPrevious.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace ItkDev\OpenIdConnectBundle\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Catch_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * When a catch block rethrows by constructing a new exception, the caught
+ * exception must be chained as `$previous` (positional 3rd argument or named
+ * `previous:`). This enforces the "wrap at the boundary" rule in CLAUDE.md
+ * preserving `getPrevious()` traversal for logs and debugging.
+ *
+ * Escape hatch: add "phpstan-ignore throw.unchainedPrevious" on the throw line
+ * with a justification comment when the rethrow is intentionally unrelated to
+ * the caught cause.
+ *
+ * @implements Rule<Catch_>
+ */
+final class WrappedExceptionChainsPrevious implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Catch_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (null === $node->var) {
+            return [];
+        }
+
+        $catchVarName = $node->var->name;
+        if (!is_string($catchVarName)) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->findThrows($node->stmts) as $throw) {
+            $newExpr = $throw->expr;
+            if (!$newExpr instanceof New_) {
+                continue;
+            }
+
+            if ($this->chainsCaughtAsPrevious($newExpr, $catchVarName)) {
+                continue;
+            }
+
+            $thrownLabel = $this->describeNewExpr($newExpr);
+            $errors[] = RuleErrorBuilder::message(sprintf(
+                'Exception %s thrown inside catch($%s) does not chain the caught exception as `previous`. Pass `previous: $%s` (or as the 3rd positional argument), or annotate with `@phpstan-ignore throw.unchainedPrevious` when the unrelated throw is intentional.',
+                $thrownLabel,
+                $catchVarName,
+                $catchVarName,
+            ))
+                ->identifier('throw.unchainedPrevious')
+                ->line($throw->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Collect every `throw` node reachable from these statements, but stop at
+     * nested catch blocks — those bind a different catch variable and are
+     * inspected by their own rule invocation.
+     *
+     * @param Node[] $stmts
+     *
+     * @return list<Throw_>
+     */
+    private function findThrows(array $stmts): array
+    {
+        $found = [];
+        foreach ($stmts as $stmt) {
+            $this->collect($stmt, $found);
+        }
+
+        return $found;
+    }
+
+    /**
+     * @param list<Throw_> $found
+     */
+    private function collect(Node $node, array &$found): void
+    {
+        if ($node instanceof Catch_) {
+            // A nested catch owns its own catch variable scope; its rethrows are
+            // checked when that catch is processed.
+            return;
+        }
+
+        if ($node instanceof Throw_) {
+            $found[] = $node;
+        }
+
+        foreach ($node->getSubNodeNames() as $subName) {
+            $sub = $node->{$subName}; // @phpstan-ignore property.dynamicName (walking an AST node's children requires a dynamic subnode name lookup; the names come from getSubNodeNames() and are intrinsically dynamic)
+            if ($sub instanceof Node) {
+                $this->collect($sub, $found);
+            } elseif (is_array($sub)) {
+                foreach ($sub as $item) {
+                    if ($item instanceof Node) {
+                        $this->collect($item, $found);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Accept either a named `previous: $catchVar` argument, or any argument whose
+     * value is directly the catch variable. The latter covers conventional PHP
+     * exceptions (positional $previous at index 2) and Symfony's HTTP exception
+     * subclasses (which bake the status code into the type and place $previous
+     * at index 1). Passing the catch variable as any other slot is unusual in
+     * practice; the looser check trades a rare false-negative for not depending
+     * on constructor reflection.
+     */
+    private function chainsCaughtAsPrevious(New_ $new, string $catchVarName): bool
+    {
+        foreach ($new->args as $arg) {
+            if (!$arg instanceof Arg) {
+                continue;
+            }
+
+            if (null !== $arg->name && 'previous' === $arg->name->name) {
+                return $this->valueIsVariable($arg->value, $catchVarName);
+            }
+
+            if (null === $arg->name && $this->valueIsVariable($arg->value, $catchVarName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function valueIsVariable(Node\Expr $expr, string $name): bool
+    {
+        return $expr instanceof Variable && is_string($expr->name) && $expr->name === $name;
+    }
+
+    private function describeNewExpr(New_ $new): string
+    {
+        $cls = $new->class;
+        if ($cls instanceof Node\Name) {
+            return $cls->toString();
+        }
+
+        return 'anonymous/dynamic exception';
+    }
+}

--- a/phpstan/Rule/WrappedExceptionChainsPrevious.php
+++ b/phpstan/Rule/WrappedExceptionChainsPrevious.php
@@ -15,7 +15,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * When a catch block rethrows by constructing a new exception, the caught
  * exception must be chained as `$previous` (positional 3rd argument or named
- * `previous:`). This enforces the "wrap at the boundary" rule in CLAUDE.md
+ * `previous:`). This enforces the "wrap at the boundary" rule in ADR 001,
  * preserving `getPrevious()` traversal for logs and debugging.
  *
  * Escape hatch: add "phpstan-ignore throw.unchainedPrevious" on the throw line

--- a/phpstan/exception-contract.neon
+++ b/phpstan/exception-contract.neon
@@ -1,0 +1,9 @@
+services:
+    -
+        class: ItkDev\OpenIdConnectBundle\PHPStan\Rule\ThrownExceptionImplementsBundleMarker
+        tags:
+            - phpstan.rules.rule
+    -
+        class: ItkDev\OpenIdConnectBundle\PHPStan\Rule\WrappedExceptionChainsPrevious
+        tags:
+            - phpstan.rules.rule

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -2,7 +2,7 @@
 
 namespace ItkDev\OpenIdConnectBundle\Controller;
 
-use ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException;
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
 use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -27,7 +27,7 @@ class LoginController extends AbstractController
      *
      * @throws NotFoundHttpException           Provider key not configured (404)
      * @throws ServiceUnavailableHttpException IdP unreachable, returned a non-200, served malformed JSON, or local cache failed (503)
-     * @throws ItkOpenIdConnectException       Other provider-init failures (e.g. BadUrlException for a misconfigured metadata_url) — server-side configuration bugs that intentionally bubble as 500
+     * @throws OpenIdConnectExceptionInterface Other provider-init failures (e.g. BadUrlException for a misconfigured metadata_url) — server-side configuration bugs that intentionally bubble as 500
      * @throws \InvalidArgumentException       Declared by league\AbstractProvider::getAuthorizationUrl for missing scope/state. Unreachable in this flow (state always provided, getDefaultScopes() implemented in upstream OpenIdConfigurationProvider). Bubbles as 500 if it ever fires — programmer error.
      */
     public function login(Request $request, SessionInterface $session, string $providerKey): RedirectResponse
@@ -53,7 +53,7 @@ class LoginController extends AbstractController
                 'response_type' => 'code',
                 'scope' => 'openid email profile',
             ]);
-        } catch (ItkOpenIdConnectException $e) {
+        } catch (OpenIdConnectExceptionInterface $e) {
             // Building the authorization URL fetches the IdP's discovery
             // document. Surface upstream/transport/cache failures as 503 with
             // the cause chained, rather than an unhandled 500.

--- a/src/Exception/CacheException.php
+++ b/src/Exception/CacheException.php
@@ -2,6 +2,6 @@
 
 namespace ItkDev\OpenIdConnectBundle\Exception;
 
-class CacheException extends ItkOpenIdConnectBundleException
+class CacheException extends \RuntimeException implements OpenIdConnectBundleExceptionInterface
 {
 }

--- a/src/Exception/InvalidProviderException.php
+++ b/src/Exception/InvalidProviderException.php
@@ -2,6 +2,6 @@
 
 namespace ItkDev\OpenIdConnectBundle\Exception;
 
-class InvalidProviderException extends ItkOpenIdConnectBundleException
+class InvalidProviderException extends \InvalidArgumentException implements OpenIdConnectBundleExceptionInterface
 {
 }

--- a/src/Exception/ItkOpenIdConnectBundleException.php
+++ b/src/Exception/ItkOpenIdConnectBundleException.php
@@ -2,6 +2,12 @@
 
 namespace ItkDev\OpenIdConnectBundle\Exception;
 
-abstract class ItkOpenIdConnectBundleException extends \Exception
+/**
+ * @deprecated since 5.0, will be removed in 6.0.
+ *             Catch {@see OpenIdConnectBundleExceptionInterface} instead. Concrete bundle
+ *             exceptions no longer extend this class; they extend the SPL exception that best
+ *             describes the failure category and implement the marker interface.
+ */
+abstract class ItkOpenIdConnectBundleException extends \Exception implements OpenIdConnectBundleExceptionInterface
 {
 }

--- a/src/Exception/OpenIdConnectBundleExceptionInterface.php
+++ b/src/Exception/OpenIdConnectBundleExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ItkDev\OpenIdConnectBundle\Exception;
+
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
+
+/**
+ * Marker interface for every exception thrown from a public method of this bundle.
+ *
+ * Extends the upstream library marker so a consumer can catch every OIDC failure
+ * from both packages with a single `catch (OpenIdConnectExceptionInterface $e)`,
+ * or scope to bundle-only failures with `catch (OpenIdConnectBundleExceptionInterface $e)`.
+ */
+interface OpenIdConnectBundleExceptionInterface extends OpenIdConnectExceptionInterface
+{
+}

--- a/src/Exception/TokenNotFoundException.php
+++ b/src/Exception/TokenNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace ItkDev\OpenIdConnectBundle\Exception;
 
-class TokenNotFoundException extends ItkOpenIdConnectBundleException
+class TokenNotFoundException extends \RuntimeException implements OpenIdConnectBundleExceptionInterface
 {
 }

--- a/src/Exception/UserDoesNotExistException.php
+++ b/src/Exception/UserDoesNotExistException.php
@@ -2,6 +2,6 @@
 
 namespace ItkDev\OpenIdConnectBundle\Exception;
 
-class UserDoesNotExistException extends ItkOpenIdConnectBundleException
+class UserDoesNotExistException extends \RuntimeException implements OpenIdConnectBundleExceptionInterface
 {
 }

--- a/src/Exception/UsernameDoesNotExistException.php
+++ b/src/Exception/UsernameDoesNotExistException.php
@@ -2,6 +2,6 @@
 
 namespace ItkDev\OpenIdConnectBundle\Exception;
 
-class UsernameDoesNotExistException extends ItkOpenIdConnectBundleException
+class UsernameDoesNotExistException extends \InvalidArgumentException implements OpenIdConnectBundleExceptionInterface
 {
 }

--- a/src/Security/CliLoginTokenAuthenticator.php
+++ b/src/Security/CliLoginTokenAuthenticator.php
@@ -41,7 +41,7 @@ class CliLoginTokenAuthenticator extends AbstractAuthenticator
     public function authenticate(Request $request): Passport
     {
         $token = (string) $request->query->get('loginToken');
-        if (empty($token)) {
+        if ('' === $token) {
             // The token header was empty, authentication fails with HTTP Status
             // Code 401 "Unauthorized"
             throw new CustomUserMessageAuthenticationException('No login token provided');

--- a/src/Security/OpenIdConfigurationProviderManager.php
+++ b/src/Security/OpenIdConfigurationProviderManager.php
@@ -88,7 +88,7 @@ class OpenIdConfigurationProviderManager
                 $providerOptions['allowHttp'] = $options['allow_http'];
             }
 
-            if (!empty($options['http_client_options'])) {
+            if (isset($options['http_client_options']) && [] !== $options['http_client_options']) {
                 $providerOptions += $options['http_client_options'];
             }
 

--- a/src/Security/OpenIdConfigurationProviderManager.php
+++ b/src/Security/OpenIdConfigurationProviderManager.php
@@ -2,7 +2,7 @@
 
 namespace ItkDev\OpenIdConnectBundle\Security;
 
-use ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException;
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
 use ItkDev\OpenIdConnect\Security\OpenIdConfigurationProvider;
 use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -53,8 +53,7 @@ class OpenIdConfigurationProviderManager
     /**
      * Get a provider by key.
      *
-     * @throws InvalidProviderException
-     * @throws ItkOpenIdConnectException
+     * @throws OpenIdConnectExceptionInterface
      */
     public function getProvider(string $key): OpenIdConfigurationProvider
     {
@@ -92,6 +91,7 @@ class OpenIdConfigurationProviderManager
                 $providerOptions += $options['http_client_options'];
             }
 
+            // @phpstan-ignore argument.type (library 5.0 narrowed $options to a strict array shape; the incremental build above is verified by the manager's tests but PHPStan can't track its evolution to the final shape)
             $this->providers[$key] = new OpenIdConfigurationProvider($providerOptions);
         }
 

--- a/src/Security/OpenIdLoginAuthenticator.php
+++ b/src/Security/OpenIdLoginAuthenticator.php
@@ -2,10 +2,8 @@
 
 namespace ItkDev\OpenIdConnectBundle\Security;
 
-use ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException;
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
 use ItkDev\OpenIdConnect\Exception\ValidationException;
-use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
-use Psr\Http\Client\ClientExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -36,10 +34,7 @@ abstract class OpenIdLoginAuthenticator extends AbstractAuthenticator implements
      *
      * @return array<string, string> Array of claims
      *
-     * @throws InvalidProviderException
-     * @throws ItkOpenIdConnectException
-     * @throws ValidationException
-     * @throws ClientExceptionInterface
+     * @throws OpenIdConnectExceptionInterface
      */
     protected function validateClaims(Request $request): array
     {
@@ -70,7 +65,7 @@ abstract class OpenIdLoginAuthenticator extends AbstractAuthenticator implements
             $idToken = $provider->getIdToken($code);
             $claims = $provider->validateIdToken($idToken, $oauth2nonce);
             // Authentication successful
-        } catch (ItkOpenIdConnectException $exception) {
+        } catch (OpenIdConnectExceptionInterface $exception) {
             // Handle failed authentication
             throw new ValidationException($exception->getMessage(), previous: $exception);
         }

--- a/src/Util/CliLoginHelper.php
+++ b/src/Util/CliLoginHelper.php
@@ -3,6 +3,7 @@
 namespace ItkDev\OpenIdConnectBundle\Util;
 
 use ItkDev\OpenIdConnectBundle\Exception\CacheException;
+use ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface;
 use ItkDev\OpenIdConnectBundle\Exception\TokenNotFoundException;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
@@ -23,7 +24,7 @@ class CliLoginHelper
     /**
      * Creates login token for CLI login.
      *
-     * @throws CacheException
+     * @throws OpenIdConnectBundleExceptionInterface
      */
     public function createToken(string $username): string
     {
@@ -65,8 +66,11 @@ class CliLoginHelper
     /**
      * Gets username from login token.
      *
+     * `TokenNotFoundException` is part of the public contract — {@see CliLoginTokenAuthenticator}
+     * catches it specifically to distinguish "no such token" from other cache failures.
+     *
      * @throws TokenNotFoundException
-     * @throws CacheException
+     * @throws OpenIdConnectBundleExceptionInterface
      */
     public function getUsername(string $token): ?string
     {

--- a/src/Util/CliLoginHelper.php
+++ b/src/Util/CliLoginHelper.php
@@ -105,7 +105,10 @@ class CliLoginHelper
 
     public function decodeKey(string $encodedKey): string
     {
-        $decodedKeyWithNamespace = base64_decode($encodedKey);
+        $decodedKeyWithNamespace = base64_decode($encodedKey, true);
+        if (false === $decodedKeyWithNamespace) {
+            return $encodedKey;
+        }
 
         // Remove namespace
         $key = str_replace(self::ITK_NAMESPACE, '', $decodedKeyWithNamespace);

--- a/tests/Command/UserLoginCommandTest.php
+++ b/tests/Command/UserLoginCommandTest.php
@@ -4,6 +4,7 @@ namespace ItkDev\OpenIdConnectBundle\Tests\Command;
 
 use ItkDev\OpenIdConnectBundle\Command\UserLoginCommand;
 use ItkDev\OpenIdConnectBundle\Util\CliLoginHelper;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -13,8 +14,11 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class UserLoginCommandTest extends TestCase
 {
+    /** @var CliLoginHelper&Stub */
     private CliLoginHelper $stubCliLoginHelper;
+    /** @var UrlGeneratorInterface&Stub */
     private UrlGeneratorInterface $stubUrlGenerator;
+    /** @var UserProviderInterface&Stub */
     private UserProviderInterface $stubUserProvider;
     private UserLoginCommand $command;
 

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -11,8 +11,6 @@ use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -39,8 +37,7 @@ class LoginControllerTest extends TestCase
 
         $controller = $this->createController($mockProvider);
 
-        $stubRequest = $this->createStub(Request::class);
-        $stubRequest->query = new InputBag(['provider' => 'test']);
+        $request = new Request(query: ['provider' => 'test']);
         $mockSession = $this->createMock(SessionInterface::class);
         $matcher = $this->exactly(3);
         $mockSession
@@ -60,8 +57,7 @@ class LoginControllerTest extends TestCase
                 }
             });
 
-        $response = $controller->login($stubRequest, $mockSession, 'test');
-        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $response = $controller->login($request, $mockSession, 'test');
         $this->assertSame('https://test.com', $response->getTargetUrl());
     }
 
@@ -79,7 +75,7 @@ class LoginControllerTest extends TestCase
         $controller = new LoginController($mockProviderManager);
 
         try {
-            $controller->login($this->createStub(Request::class), $this->createStub(SessionInterface::class), 'bogus');
+            $controller->login(new Request(), $this->createStub(SessionInterface::class), 'bogus');
         } catch (NotFoundHttpException $thrown) {
             $this->assertSame(404, $thrown->getStatusCode());
             $this->assertStringContainsString('bogus', $thrown->getMessage());
@@ -111,7 +107,7 @@ class LoginControllerTest extends TestCase
         $controller = $this->createController($stubProvider);
 
         try {
-            $controller->login($this->createStub(Request::class), $this->createStub(SessionInterface::class), 'test');
+            $controller->login(new Request(), $this->createStub(SessionInterface::class), 'test');
         } catch (ServiceUnavailableHttpException $thrown) {
             $this->assertSame(503, $thrown->getStatusCode());
             $this->assertStringContainsString('test', $thrown->getMessage());

--- a/tests/Exception/ExceptionHierarchyTest.php
+++ b/tests/Exception/ExceptionHierarchyTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace ItkDev\OpenIdConnectBundle\Tests\Exception;
+
+use ItkDev\OpenIdConnect\Exception\HttpException as LibraryHttpException;
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
+use ItkDev\OpenIdConnectBundle\Exception\CacheException;
+use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
+use ItkDev\OpenIdConnectBundle\Exception\ItkOpenIdConnectBundleException;
+use ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface;
+use ItkDev\OpenIdConnectBundle\Exception\TokenNotFoundException;
+use ItkDev\OpenIdConnectBundle\Exception\UserDoesNotExistException;
+use ItkDev\OpenIdConnectBundle\Exception\UsernameDoesNotExistException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the bundle's exception contract documented in `CLAUDE.md` "Exceptions":
+ *
+ * - Every concrete bundle exception implements {@see OpenIdConnectBundleExceptionInterface}
+ *   (and therefore {@see OpenIdConnectExceptionInterface} from the upstream library).
+ * - Each concrete extends the SPL type that best describes its failure category.
+ * - A single `catch (OpenIdConnectExceptionInterface $e)` matches every concrete
+ *   from both the bundle and the upstream library.
+ *
+ * A change that breaks any of these properties is a MAJOR version bump per
+ * SemVer commitments — failing this test class is the early warning.
+ */
+class ExceptionHierarchyTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{class-string<\Throwable>, class-string<\Throwable>}>
+     */
+    public static function concreteProvider(): iterable
+    {
+        // Invalid input to a public method → \InvalidArgumentException
+        yield 'InvalidProviderException' => [InvalidProviderException::class, \InvalidArgumentException::class];
+        yield 'UsernameDoesNotExistException' => [UsernameDoesNotExistException::class, \InvalidArgumentException::class];
+
+        // Runtime conditions → \RuntimeException
+        yield 'CacheException' => [CacheException::class, \RuntimeException::class];
+        yield 'TokenNotFoundException' => [TokenNotFoundException::class, \RuntimeException::class];
+        yield 'UserDoesNotExistException' => [UserDoesNotExistException::class, \RuntimeException::class];
+    }
+
+    /**
+     * @param class-string<\Throwable> $concrete
+     * @param class-string<\Throwable> $expectedSplParent
+     */
+    #[DataProvider('concreteProvider')]
+    public function testConcreteImplementsBundleMarker(string $concrete, string $expectedSplParent): void
+    {
+        $instance = new $concrete('test');
+        $this->assertInstanceOf(OpenIdConnectBundleExceptionInterface::class, $instance);
+    }
+
+    /**
+     * @param class-string<\Throwable> $concrete
+     * @param class-string<\Throwable> $expectedSplParent
+     */
+    #[DataProvider('concreteProvider')]
+    public function testConcreteImplementsLibraryMarker(string $concrete, string $expectedSplParent): void
+    {
+        $instance = new $concrete('test');
+        $this->assertInstanceOf(OpenIdConnectExceptionInterface::class, $instance);
+    }
+
+    /**
+     * @param class-string<\Throwable> $concrete
+     * @param class-string<\Throwable> $expectedSplParent
+     */
+    #[DataProvider('concreteProvider')]
+    public function testConcreteExtendsExpectedSplParent(string $concrete, string $expectedSplParent): void
+    {
+        $instance = new $concrete('test');
+        $this->assertInstanceOf($expectedSplParent, $instance);
+    }
+
+    /**
+     * @param class-string<\Throwable> $concrete
+     * @param class-string<\Throwable> $expectedSplParent
+     */
+    #[DataProvider('concreteProvider')]
+    public function testCatchByBundleMarkerMatchesEveryConcrete(string $concrete, string $expectedSplParent): void
+    {
+        try {
+            throw new $concrete('test');
+        } catch (OpenIdConnectBundleExceptionInterface $caught) {
+            $this->assertInstanceOf($concrete, $caught);
+
+            return;
+        }
+        // @phpstan-ignore deadCode.unreachable (safety net if a future regression breaks the catch-by-marker contract)
+        $this->fail('Catch on OpenIdConnectBundleExceptionInterface should have matched '.$concrete);
+    }
+
+    /**
+     * Cross-package contract: a single `catch (OpenIdConnectExceptionInterface $e)`
+     * must catch failures from both the library and the bundle. This is the whole
+     * point of the bundle marker extending the library marker.
+     */
+    public function testLibraryMarkerCatchesBothPackages(): void
+    {
+        $caught = [];
+
+        foreach ([new LibraryHttpException('lib'), new CacheException('bundle')] as $exception) {
+            try {
+                throw $exception;
+            } catch (OpenIdConnectExceptionInterface $e) {
+                $caught[] = $e::class;
+            }
+        }
+
+        $this->assertSame([LibraryHttpException::class, CacheException::class], $caught);
+    }
+
+    public function testDeprecatedAbstractBaseImplementsBundleMarker(): void
+    {
+        // `ItkOpenIdConnectBundleException` is kept as a deprecated alias through 5.x.
+        // Concrete bundle exceptions no longer extend it, but it still implements the
+        // marker so any consumer-defined subclass remains catchable via the marker.
+        // PHPStan can statically prove the assertion holds today; the test exists so
+        // the day a refactor removes the implements, the failure is loud.
+        $deprecated = ItkOpenIdConnectBundleException::class; // @phpstan-ignore classConstant.deprecatedClass (the test asserts a property of this deprecated class on purpose)
+        // @phpstan-ignore method.alreadyNarrowedType (the assertion is the guard — PHPStan proves it today; the test fails the day the guard stops holding)
+        $this->assertTrue(
+            // @phpstan-ignore function.alreadyNarrowedType (same as above — the static proof IS the contract being asserted)
+            is_subclass_of($deprecated, OpenIdConnectBundleExceptionInterface::class),
+            'Deprecated abstract base must continue to implement the bundle marker through 5.x.',
+        );
+    }
+}

--- a/tests/Exception/ExceptionHierarchyTest.php
+++ b/tests/Exception/ExceptionHierarchyTest.php
@@ -15,7 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Locks the bundle's exception contract documented in `CLAUDE.md` "Exceptions":
+ * Locks the bundle's exception contract (see
+ * docs/adr/001-marker-interface-exception-hierarchy.md):
  *
  * - Every concrete bundle exception implements {@see OpenIdConnectBundleExceptionInterface}
  *   (and therefore {@see OpenIdConnectExceptionInterface} from the upstream library).

--- a/tests/ItkDevOpenIdConnectBundleTestingKernel.php
+++ b/tests/ItkDevOpenIdConnectBundleTestingKernel.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class ItkDevOpenIdConnectBundleTestingKernel extends Kernel
 {
+    /**
+     * @param list<string> $pathToConfigs
+     */
     public function __construct(
         private readonly array $pathToConfigs,
     ) {

--- a/tests/Security/CliLoginTokenAuthenticatorTest.php
+++ b/tests/Security/CliLoginTokenAuthenticatorTest.php
@@ -7,8 +7,8 @@ use ItkDev\OpenIdConnectBundle\Exception\TokenNotFoundException;
 use ItkDev\OpenIdConnectBundle\Exception\UsernameDoesNotExistException;
 use ItkDev\OpenIdConnectBundle\Security\CliLoginTokenAuthenticator;
 use ItkDev\OpenIdConnectBundle\Util\CliLoginHelper;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -20,7 +20,9 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 class CliLoginTokenAuthenticatorTest extends TestCase
 {
     private CliLoginTokenAuthenticator $authenticator;
+    /** @var CliLoginHelper&Stub */
     private CliLoginHelper $stubCliLoginHelper;
+    /** @var UrlGeneratorInterface&Stub */
     private UrlGeneratorInterface $stubRouter;
 
     protected function setUp(): void
@@ -37,24 +39,21 @@ class CliLoginTokenAuthenticatorTest extends TestCase
 
     public function testSupportsWithLoginToken(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['loginToken' => 'some-token']);
+        $request = new Request(query: ['loginToken' => 'some-token']);
 
         $this->assertTrue($this->authenticator->supports($request));
     }
 
     public function testSupportsWithoutLoginToken(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag();
+        $request = new Request();
 
         $this->assertFalse($this->authenticator->supports($request));
     }
 
     public function testAuthenticateWithEmptyToken(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['loginToken' => '']);
+        $request = new Request(query: ['loginToken' => '']);
 
         $this->expectException(CustomUserMessageAuthenticationException::class);
         $this->expectExceptionMessage('No login token provided');
@@ -68,8 +67,7 @@ class CliLoginTokenAuthenticatorTest extends TestCase
             ->method('getUsername')
             ->willThrowException(new TokenNotFoundException('Token does not exist'));
 
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['loginToken' => 'invalid-token']);
+        $request = new Request(query: ['loginToken' => 'invalid-token']);
 
         $this->expectException(CustomUserMessageAuthenticationException::class);
         $this->expectExceptionMessage('Cannot get username');
@@ -83,8 +81,7 @@ class CliLoginTokenAuthenticatorTest extends TestCase
             ->method('getUsername')
             ->willThrowException(new CacheException('Cache error'));
 
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['loginToken' => 'some-token']);
+        $request = new Request(query: ['loginToken' => 'some-token']);
 
         $this->expectException(CustomUserMessageAuthenticationException::class);
         $this->expectExceptionMessage('Cannot get username');
@@ -98,8 +95,7 @@ class CliLoginTokenAuthenticatorTest extends TestCase
             ->method('getUsername')
             ->willReturn(null);
 
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['loginToken' => 'some-token']);
+        $request = new Request(query: ['loginToken' => 'some-token']);
 
         $this->expectException(UsernameDoesNotExistException::class);
 
@@ -112,12 +108,12 @@ class CliLoginTokenAuthenticatorTest extends TestCase
             ->method('getUsername')
             ->willReturn('test@example.com');
 
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['loginToken' => 'valid-token']);
+        $request = new Request(query: ['loginToken' => 'valid-token']);
 
         $passport = $this->authenticator->authenticate($request);
 
         $userBadge = $passport->getBadge(UserBadge::class);
+        $this->assertNotNull($userBadge, 'Passport must carry a UserBadge for a valid token.');
         $this->assertSame('test@example.com', $userBadge->getUserIdentifier());
     }
 
@@ -127,10 +123,9 @@ class CliLoginTokenAuthenticatorTest extends TestCase
             ->method('generate')
             ->willReturn('/login');
 
-        $request = $this->createStub(Request::class);
         $token = $this->createStub(TokenInterface::class);
 
-        $response = $this->authenticator->onAuthenticationSuccess($request, $token, 'main');
+        $response = $this->authenticator->onAuthenticationSuccess(new Request(), $token, 'main');
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('/login', $response->getTargetUrl());
@@ -138,12 +133,11 @@ class CliLoginTokenAuthenticatorTest extends TestCase
 
     public function testOnAuthenticationFailure(): void
     {
-        $request = $this->createStub(Request::class);
         $exception = new AuthenticationException();
 
         $this->expectException(AuthenticationException::class);
         $this->expectExceptionMessage('Error occurred validating login token');
 
-        $this->authenticator->onAuthenticationFailure($request, $exception);
+        $this->authenticator->onAuthenticationFailure(new Request(), $exception);
     }
 }

--- a/tests/Security/OpenIdConfigurationProviderManagerTest.php
+++ b/tests/Security/OpenIdConfigurationProviderManagerTest.php
@@ -6,12 +6,14 @@ use GuzzleHttp\Client as GuzzleClient;
 use ItkDev\OpenIdConnect\Security\OpenIdConfigurationProvider;
 use ItkDev\OpenIdConnectBundle\Exception\InvalidProviderException;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Routing\RouterInterface;
 
 class OpenIdConfigurationProviderManagerTest extends TestCase
 {
+    /** @var RouterInterface&Stub */
     private RouterInterface $stubRouter;
 
     protected function setUp(): void
@@ -19,6 +21,9 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
         $this->stubRouter = $this->createStub(RouterInterface::class);
     }
 
+    /**
+     * @return array{metadata_url: string, client_id: string, client_secret: string}
+     */
     private function getBaseProviderConfig(): array
     {
         return [
@@ -28,6 +33,14 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
         ];
     }
 
+    /**
+     * Test helper: callers build provider arrays from {@see getBaseProviderConfig()}
+     * plus optional fields, so the parameter is intentionally typed loosely. The
+     * production manager constructor has the precise array shape.
+     *
+     * @param array<string, array<string, mixed>> $providers
+     * @param array<string, mixed>                $defaultOptions
+     */
     private function createManager(array $providers, array $defaultOptions = []): OpenIdConfigurationProviderManager
     {
         $config = [
@@ -38,6 +51,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
             'providers' => $providers,
         ];
 
+        // @phpstan-ignore argument.type (test helper relaxes the strict provider shape declared by the production constructor — callers build configs ad-hoc from getBaseProviderConfig() plus optional fields)
         return new OpenIdConfigurationProviderManager($this->stubRouter, $config);
     }
 

--- a/tests/Security/OpenIdLoginAuthenticatorTest.php
+++ b/tests/Security/OpenIdLoginAuthenticatorTest.php
@@ -3,6 +3,7 @@
 namespace ItkDev\OpenIdConnectBundle\Tests\Security;
 
 use ItkDev\OpenIdConnect\Exception\ClaimsException;
+use ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface;
 use ItkDev\OpenIdConnect\Exception\ValidationException;
 use ItkDev\OpenIdConnect\Security\OpenIdConfigurationProvider;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
@@ -93,6 +94,11 @@ class OpenIdLoginAuthenticatorTest extends TestCase
         } catch (ValidationException $thrown) {
             $this->assertSame('test message', $thrown->getMessage());
             $this->assertSame($cause, $thrown->getPrevious(), 'Original cause must be chained');
+            $this->assertInstanceOf(
+                OpenIdConnectExceptionInterface::class,
+                $thrown->getPrevious(),
+                'Wrapped cause must satisfy the library marker contract',
+            );
 
             return;
         }

--- a/tests/Security/OpenIdLoginAuthenticatorTest.php
+++ b/tests/Security/OpenIdLoginAuthenticatorTest.php
@@ -7,8 +7,8 @@ use ItkDev\OpenIdConnect\Exception\ValidationException;
 use ItkDev\OpenIdConnect\Security\OpenIdConfigurationProvider;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdLoginAuthenticator;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 class OpenIdLoginAuthenticatorTest extends TestCase
 {
     private OpenIdLoginAuthenticator $authenticator;
+    /** @var OpenIdConfigurationProviderManager&Stub */
     private OpenIdConfigurationProviderManager $stubProviderManager;
 
     protected function setUp(): void
@@ -27,8 +28,7 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
     public function testSupports(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag();
+        $request = new Request();
 
         $this->assertFalse($this->authenticator->supports($request));
 
@@ -43,18 +43,15 @@ class OpenIdLoginAuthenticatorTest extends TestCase
     {
         $this->expectException(AuthenticationException::class);
 
-        $stubRequest = $this->createStub(Request::class);
         $exception = new AuthenticationException();
 
-        $this->authenticator->onAuthenticationFailure($stubRequest, $exception);
+        $this->authenticator->onAuthenticationFailure(new Request(), $exception);
     }
 
     public function testValidateClaimsWrongState(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['state' => 'wrong_test_state']);
-
-        $this->setupStubSessionOnRequest($request);
+        $request = new Request(query: ['state' => 'wrong_test_state']);
+        $this->setSessionOnRequest($request);
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Invalid state');
@@ -63,10 +60,8 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
     public function testValidateClaimsEmptyNonce(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['state' => 'test_state']);
-
-        $this->setupStubSessionOnRequest($request, nonce: null);
+        $request = new Request(query: ['state' => 'test_state']);
+        $this->setSessionOnRequest($request, nonce: null);
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Nonce empty or not found');
@@ -75,10 +70,8 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
     public function testValidateClaimsMissingCode(): void
     {
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['state' => 'test_state']);
-
-        $this->setupStubSessionOnRequest($request);
+        $request = new Request(query: ['state' => 'test_state']);
+        $this->setSessionOnRequest($request);
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Missing or invalid code');
@@ -92,10 +85,8 @@ class OpenIdLoginAuthenticatorTest extends TestCase
         $stubProvider->method('validateIdToken')->willThrowException($cause);
         $this->stubProviderManager->method('getProvider')->willReturn($stubProvider);
 
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['state' => 'test_state', 'code' => 'test_code']);
-
-        $this->setupStubSessionOnRequest($request);
+        $request = new Request(query: ['state' => 'test_state', 'code' => 'test_code']);
+        $this->setSessionOnRequest($request);
 
         try {
             $this->authenticator->authenticate($request);
@@ -119,17 +110,15 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
         $this->stubProviderManager->method('getProvider')->willReturn($stubProvider);
 
-        $request = $this->createStub(Request::class);
-        $request->query = new InputBag(['state' => 'test_state', 'code' => 'test_code']);
-
-        $this->setupStubSessionOnRequest($request);
+        $request = new Request(query: ['state' => 'test_state', 'code' => 'test_code']);
+        $this->setSessionOnRequest($request);
 
         $passport = $this->authenticator->authenticate($request);
 
         $this->assertSame('test@test.com', $passport->getUser()->getUserIdentifier());
     }
 
-    private function setupStubSessionOnRequest(Request $request, ?string $nonce = 'test_nonce'): void
+    private function setSessionOnRequest(Request $request, ?string $nonce = 'test_nonce'): void
     {
         $stubSession = $this->createStub(SessionInterface::class);
         $map = [
@@ -139,6 +128,6 @@ class OpenIdLoginAuthenticatorTest extends TestCase
         ];
         $stubSession->method('remove')->willReturnMap($map);
 
-        $request->method('getSession')->willReturn($stubSession);
+        $request->setSession($stubSession);
     }
 }

--- a/tests/Security/TestAuthenticator.php
+++ b/tests/Security/TestAuthenticator.php
@@ -20,18 +20,18 @@ class TestAuthenticator extends OpenIdLoginAuthenticator
         return new SelfValidatingPassport(
             new UserBadge(
                 $claims['email'],
-                fn ($email) => new TestUser($email)
+                fn (string $email) => new TestUser($email)
             )
         );
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
     {
-        // TODO: Implement onAuthenticationSuccess() method.
+        return null;
     }
 
     public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
-        // TODO: Implement start() method.
+        throw new \LogicException('Test stub: start() is not implemented for this fixture.');
     }
 }

--- a/tests/Security/TestUser.php
+++ b/tests/Security/TestUser.php
@@ -6,19 +6,24 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class TestUser implements UserInterface
 {
-    public function __construct(
-        private readonly string $email,
-    ) {
+    /** @var non-empty-string */
+    private readonly string $email;
+
+    public function __construct(string $email)
+    {
+        if ('' === $email) {
+            throw new \InvalidArgumentException('TestUser requires a non-empty email.');
+        }
+        $this->email = $email;
     }
 
     public function getRoles(): array
     {
-        // TODO: Implement getRoles() method.
+        return [];
     }
 
     public function eraseCredentials(): void
     {
-        // TODO: Implement eraseCredentials() method.
     }
 
     public function getUserIdentifier(): string

--- a/tests/Util/CliLoginHelperTest.php
+++ b/tests/Util/CliLoginHelperTest.php
@@ -3,7 +3,7 @@
 namespace ItkDev\OpenIdConnectBundle\Tests\Util;
 
 use ItkDev\OpenIdConnectBundle\Exception\CacheException;
-use ItkDev\OpenIdConnectBundle\Exception\ItkOpenIdConnectBundleException;
+use ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface;
 use ItkDev\OpenIdConnectBundle\Util\CliLoginHelper;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
@@ -40,7 +40,7 @@ class CliLoginHelperTest extends TestCase
 
     public function testThrowExceptionIfTokenDoesNotExist(): void
     {
-        $this->expectException(ItkOpenIdConnectBundleException::class);
+        $this->expectException(OpenIdConnectBundleExceptionInterface::class);
 
         $cache = new ArrayAdapter();
 
@@ -74,7 +74,7 @@ class CliLoginHelperTest extends TestCase
         $username = $cliHelper->getUsername($token);
         $this->assertEquals($testUser, $username);
 
-        $this->expectException(ItkOpenIdConnectBundleException::class);
+        $this->expectException(OpenIdConnectBundleExceptionInterface::class);
 
         $cliHelper->getUsername($token);
     }

--- a/tests/Util/CliLoginHelperTest.php
+++ b/tests/Util/CliLoginHelperTest.php
@@ -26,6 +26,18 @@ class CliLoginHelperTest extends TestCase
         $this->assertEquals($randomUsername, $decodedUsername);
     }
 
+    public function testDecodeKeyReturnsInputWhenNotValidBase64(): void
+    {
+        $cache = new ArrayAdapter();
+        $cliHelper = new CliLoginHelper($cache);
+
+        // Strict base64_decode() rejects input with characters outside the
+        // base64 alphabet; decodeKey() then returns the value unchanged.
+        $notBase64 = 'not valid base64 !!@@';
+
+        $this->assertSame($notBase64, $cliHelper->decodeKey($notBase64));
+    }
+
     public function testThrowExceptionIfTokenDoesNotExist(): void
     {
         $this->expectException(ItkOpenIdConnectBundleException::class);


### PR DESCRIPTION
Cuts **5.0.0** (MAJOR) — the marker-interface exception contract migration.

Rolls the `[Unreleased]` CHANGELOG section into `5.0.0` (dated 2026-06-02) and adds `UPGRADE-5.0.md`. All the implementation already landed on `develop` via #38, #39, #40; this is the release branch into `main`.

## Headline (BREAKING)

- Every exception thrown from a public method now implements `OpenIdConnectBundleExceptionInterface`, which extends the upstream `\ItkDev\OpenIdConnect\Exception\OpenIdConnectExceptionInterface`. One `catch` handles both packages.
- Concrete exceptions re-parented onto SPL types; they no longer extend `ItkOpenIdConnectBundleException` (kept as a `@deprecated` alias through 5.x, removed in 6.0).
- `itk-dev/openid-connect` requirement bumped to `^5.0`.

## Also in 5.0

- Custom PHPStan rules lock the contract on every CI run.
- Hardened static analysis (strict/deprecation/phpunit/symfony packs, `tests/` analysed).
- `UPGRADE-5.0.md` migration guide.

## Migration

`catch (ItkOpenIdConnectBundleException $e)` → `catch (OpenIdConnectBundleExceptionInterface $e)`. SPL-level catches (`\InvalidArgumentException`, `\RuntimeException`) keep working. Full details in `UPGRADE-5.0.md`.

## Release steps after merge

1. Tag `5.0.0` on `main` (triggers the Create-Github-Release workflow).
2. Merge the tag back into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)