### PR TITLE
feat: default http client timeout to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `http_client_options.timeout` now defaults to `30` seconds when not set,
+  so a slow or hung identity provider can no longer block worker processes
+  indefinitely. Previously no timeout was applied and Guzzle's own default
+  (`0` — wait forever) was used. Set `timeout: 0` to restore the old
+  behaviour, or override per provider.
+
 ## [5.0.0] - 2026-06-02
 
 ### Changed (BREAKING)

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ Set the actual values your `env.local` file to ensure they are not committed to 
 #### Configuring the HTTP client
 
 Each provider accepts an optional `http_client_options` block that is forwarded
-to the underlying Guzzle HTTP client used by `league/oauth2-client`. This is
-useful for setting a request timeout so a slow IdP cannot block worker
-processes indefinitely.
+to the underlying Guzzle HTTP client used by `league/oauth2-client`. The bundle
+applies a sensible default `timeout` of `30` seconds so a slow IdP cannot block
+worker processes indefinitely (Guzzle's own default is `0`, i.e. wait forever).
+Override it per provider, or set it to `0` to opt back into Guzzle's behaviour.
 
 ```yaml
 itkdev_openid_connect:
@@ -166,7 +167,7 @@ itkdev_openid_connect:
         # ... existing keys ...
         # @see https://docs.guzzlephp.org/en/stable/request-options.html
         http_client_options:
-          # Float describing the total timeout of the request in seconds. Use 0 to wait indefinitely (the default behavior).
+          # Float describing the total timeout of the request in seconds. Defaults to 30; set to 0 to wait indefinitely.
           timeout: 5.0 
           # Pass a string to specify an HTTP proxy, or an array to specify different proxies for different protocols. (Default: none)
           proxy: "%env(string:HTTP_PROXY)%"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -87,10 +87,12 @@ class Configuration implements ConfigurationInterface
                                     // Uses Guzzle under the hood through itk-dev/openid-connect -> league/oauth2-client -> guzzlehttp/guzzle
                                     ->arrayNode('http_client_options')
                                         ->info('Options forwarded to the underlying Guzzle HTTP client. league/oauth2-client only forwards: timeout, proxy, verify (verify is only consulted when proxy is set).')
+                                        ->addDefaultsIfNotSet()
                                         ->children()
                                             // @see https://docs.guzzlephp.org/en/stable/request-options.html#timeout
                                             ->floatNode('timeout')
-                                                ->info('Total request timeout in seconds')
+                                                ->info('Total request timeout in seconds. Defaults to 30; set to 0 to wait indefinitely (Guzzle\'s own default).')
+                                                ->defaultValue(30.0)
                                             ->end()
                                             // @see https://docs.guzzlephp.org/en/stable/request-options.html#proxy
                                             ->scalarNode('proxy')

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -132,7 +132,7 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($httpClientOptions['verify']);
     }
 
-    public function testHttpClientOptionsAbsentByDefault(): void
+    public function testHttpClientOptionsDefaultsApplied(): void
     {
         $config = $this->processor->processConfiguration(
             $this->configuration,
@@ -140,10 +140,12 @@ class ConfigurationTest extends TestCase
         );
 
         $providerOptions = $config['openid_providers']['provider1']['options'];
-        // The block has no default value, so an omitted input must produce no
-        // http_client_options key in the processed config — otherwise an empty
-        // array would still be merged into the provider options.
-        $this->assertArrayNotHasKey('http_client_options', $providerOptions);
+        // The block carries a sensible default timeout so an omitted input still
+        // protects workers from a hung IdP. proxy/verify have no default and so
+        // stay absent (Guzzle's own defaults apply).
+        $this->assertSame(30.0, $providerOptions['http_client_options']['timeout']);
+        $this->assertArrayNotHasKey('proxy', $providerOptions['http_client_options']);
+        $this->assertArrayNotHasKey('verify', $providerOptions['http_client_options']);
     }
 
     public function testHttpClientOptionsRejectsUnknownKey(): void


### PR DESCRIPTION
## Summary
The bundle exposes `http_client_options` (`timeout`, `proxy`, `verify`) but applied no defaults. An omitted `timeout` fell through to Guzzle's default of `0` — wait indefinitely — so a slow or hung identity provider could block a worker process forever. This PR adds a sensible default for the one option where it matters.

## Features Added
* `http_client_options.timeout` now defaults to **30 seconds** when unset, bounding how long an IdP call can block a worker.
* `addDefaultsIfNotSet()` on the `http_client_options` block so the default still materializes when the block is omitted entirely (the manager merges it via `+=`).
* `proxy` (no sensible default) and `verify` (Guzzle already defaults to secure `true`) are deliberately left unset.

## Files Changed
* `src/DependencyInjection/Configuration.php` - Add `addDefaultsIfNotSet()` and `defaultValue(30.0)` on `timeout`.
* `tests/DependencyInjection/ConfigurationTest.php` - Replace `testHttpClientOptionsAbsentByDefault` with `testHttpClientOptionsDefaultsApplied`, asserting the default applies while `proxy`/`verify` stay absent.
* `README.md` - Document the new default and the `timeout: 0` opt-out.
* `CHANGELOG.md` - Add entry under `[Unreleased]`.

## Test Plan
* `task test` — full suite passes (79 tests).
* `task analyze:php` — PHPStan clean at max level.
* Configure a provider with no `http_client_options`; confirm the Guzzle client receives `timeout = 30.0`.
* Set `timeout: 0` on a provider; confirm Guzzle reverts to wait-indefinitely behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)