### PR TITLE
ci: bump codecov-action to v7

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -77,9 +77,11 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.service == 'phpfpm' && matrix.prefer == 'prefer-stable'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/unit.xml
-          fail_ci_if_error: true
+          # Coverage upload is informational; a Codecov outage (e.g. its CLI
+          # binary's GPG signature endpoint failing) must not fail the build.
+          fail_ci_if_error: false
           flags: unittests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI: bumped `codecov/codecov-action` from `v5` to `v7` (restores Codecov's
+  GPG signing key after the `codecovsecurity` account was removed, and moves
+  the bundled `github-script` to Node 24) and set `fail_ci_if_error: false`
+  so a Codecov outage no longer fails the build. No effect on the published
+  package.
 - `http_client_options.timeout` now defaults to `30` seconds when not set,
   so a slow or hung identity provider can no longer block worker processes
   indefinitely. Previously no timeout was applied and Guzzle's own default


### PR DESCRIPTION
## Why

The `develop` push CI run failed in the **Upload coverage to Codecov** step (tests themselves passed). The codecov CLI binary's GPG signature could not be verified:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

This is a Codecov-side issue: their `codecovsecurity` keybase account was deleted, breaking signature verification. **codecov-action v7.0.0** switches to `codecovsecops` with the original GPG key and fixes this.

A secondary CI warning — `actions/github-script@... is running on Node.js 20 (deprecated)` — comes from the bundled github-script inside codecov-action. **v6.0.0** bumped that to Node 24, clearing the warning.

## Changes

- Bump `codecov/codecov-action` `@v5` → `@v7` (fixes GPG signature failure + Node 20 deprecation).
- Set `fail_ci_if_error: false` — coverage upload is informational and a future Codecov outage should not gate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)