### PR TITLE
test: assert DI extension wiring and provider key normalization invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dev: strengthened DependencyInjection tests based on mutation testing
+  findings — the extension's container wiring (cache pool reference,
+  provider options mapping, CLI login route arguments) is now asserted
+  explicitly, and the documented invariant that provider keys are not
+  normalized (`my-provider` ≠ `my_provider`) is covered by a test. No
+  effect on the published package.
+
 - CI: bumped `codecov/codecov-action` from `v5` to `v7` (restores Codecov's
   GPG signing key after the `codecovsecurity` account was removed, and moves
   the bundled `github-script` to Node 24) and set `fail_ci_if_error: false`

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -163,6 +163,24 @@ class ConfigurationTest extends TestCase
         );
     }
 
+    public function testProviderKeysAreNotNormalized(): void
+    {
+        $input = $this->getMinimalConfig();
+        $input['openid_providers']['my-provider'] = $input['openid_providers']['provider1'];
+        unset($input['openid_providers']['provider1']);
+
+        $config = $this->processor->processConfiguration(
+            $this->configuration,
+            [$input]
+        );
+
+        // Provider keys are part of the public contract ('my-provider' and
+        // 'my_provider' are distinct providers), so dashes must survive
+        // config processing instead of being normalized to underscores.
+        $this->assertArrayHasKey('my-provider', $config['openid_providers']);
+        $this->assertArrayNotHasKey('my_provider', $config['openid_providers']);
+    }
+
     public function testMultipleProviders(): void
     {
         $input = $this->getMinimalConfig();

--- a/tests/DependencyInjection/ItkDevOpenIdConnectExtensionTest.php
+++ b/tests/DependencyInjection/ItkDevOpenIdConnectExtensionTest.php
@@ -48,6 +48,48 @@ class ItkDevOpenIdConnectExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition(CliLoginTokenAuthenticator::class));
     }
 
+    public function testLoadWiresProviderManagerConfig(): void
+    {
+        $extension = new ItkDevOpenIdConnectExtension();
+        $container = new ContainerBuilder();
+
+        $extension->load([$this->getBaseConfig()], $container);
+
+        $config = $container->getDefinition(OpenIdConfigurationProviderManager::class)->getArgument('$config');
+        $this->assertIsArray($config);
+
+        $defaultOptions = $config['default_providers_options'] ?? null;
+        $this->assertIsArray($defaultOptions);
+        $cacheItemPool = $defaultOptions['cacheItemPool'] ?? null;
+        $this->assertInstanceOf(Reference::class, $cacheItemPool);
+        $this->assertSame('cache.app', (string) $cacheItemPool);
+
+        // Provider options must be keyed by provider name with the
+        // intermediate 'options' level stripped.
+        $providers = $config['providers'] ?? null;
+        $this->assertIsArray($providers);
+        $this->assertSame(['test_provider'], array_keys($providers));
+        $provider = $providers['test_provider'];
+        $this->assertIsArray($provider);
+        $this->assertArrayNotHasKey('options', $provider);
+        $this->assertSame('test_id', $provider['client_id']);
+    }
+
+    public function testLoadWiresCacheAndCliLoginRoute(): void
+    {
+        $extension = new ItkDevOpenIdConnectExtension();
+        $container = new ContainerBuilder();
+
+        $extension->load([$this->getBaseConfig()], $container);
+
+        $cache = $container->getDefinition(CliLoginHelper::class)->getArgument('$cache');
+        $this->assertInstanceOf(Reference::class, $cache);
+        $this->assertSame('cache.app', (string) $cache);
+
+        $this->assertSame('test_route', $container->getDefinition(UserLoginCommand::class)->getArgument('$cliLoginRoute'));
+        $this->assertSame('test_route', $container->getDefinition(CliLoginTokenAuthenticator::class)->getArgument('$cliLoginRoute'));
+    }
+
     public function testLoadWithUserProvider(): void
     {
         $extension = new ItkDevOpenIdConnectExtension();


### PR DESCRIPTION
## Summary

First of four scoped follow-ups to #44 killing surviving mutants to push the mutation score above 90%. This PR covers `src/DependencyInjection` (8 escaped mutants — the largest single cluster).

## Features Added

* `ItkDevOpenIdConnectExtensionTest`: two new tests asserting the container wiring the extension performs — the `cacheItemPool` Reference on the provider manager config, the provider options mapping (keyed by provider name, `options` level stripped), and the `$cache`/`$cliLoginRoute` arguments on `CliLoginHelper`, `UserLoginCommand` and `CliLoginTokenAuthenticator`. Previously only `hasDefinition()` was checked, so every `replaceArgument()` call could be deleted without a failing test.
* `ConfigurationTest`: test for the documented invariant that provider keys are not normalized (`my-provider` and `my_provider` are distinct providers) — `normalizeKeys(false)` could be flipped to `true` undetected.

## Files Changed

* `tests/DependencyInjection/ItkDevOpenIdConnectExtensionTest.php` - wiring assertions
* `tests/DependencyInjection/ConfigurationTest.php` - key normalization test
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 82 tests, 182 assertions, green
* `vendor/bin/infection --filter=src/DependencyInjection` — 20/20 mutants killed (was 12/20)
* PHPStan max level + php-cs-fixer — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)