### PR TITLE
test: assert container extension is created and memoized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dev: added a test for `ItkDevOpenIdConnectBundle::getContainerExtension()`
+  asserting the custom extension is created and memoized (same instance on
+  repeated calls), prompted by mutation testing findings. No effect on the
+  published package.
+
 - CI: bumped `codecov/codecov-action` from `v5` to `v7` (restores Codecov's
   GPG signing key after the `codecovsecurity` account was removed, and moves
   the bundled `github-script` to Node 24) and set `fail_ci_if_error: false`

--- a/tests/ItkDevOpenIdConnectBundleTest.php
+++ b/tests/ItkDevOpenIdConnectBundleTest.php
@@ -4,6 +4,8 @@ namespace ItkDev\OpenIdConnectBundle\Tests;
 
 use ItkDev\OpenIdConnectBundle\Command\UserLoginCommand;
 use ItkDev\OpenIdConnectBundle\Controller\LoginController;
+use ItkDev\OpenIdConnectBundle\DependencyInjection\ItkDevOpenIdConnectExtension;
+use ItkDev\OpenIdConnectBundle\ItkDevOpenIdConnectBundle;
 use ItkDev\OpenIdConnectBundle\Security\CliLoginTokenAuthenticator;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
 use ItkDev\OpenIdConnectBundle\Security\OpenIdLoginAuthenticator;
@@ -56,5 +58,19 @@ class ItkDevOpenIdConnectBundleTest extends TestCase
         $this->assertTrue($container->has(CliLoginTokenAuthenticator::class));
         $authenticator = $container->get(CliLoginTokenAuthenticator::class);
         $this->assertInstanceOf(CliLoginTokenAuthenticator::class, $authenticator);
+    }
+
+    /**
+     * Test that the custom container extension is created and memoized.
+     */
+    public function testGetContainerExtension(): void
+    {
+        $bundle = new ItkDevOpenIdConnectBundle();
+
+        $extension = $bundle->getContainerExtension();
+        $this->assertInstanceOf(ItkDevOpenIdConnectExtension::class, $extension);
+
+        // Repeated calls must return the same instance, not recreate it.
+        $this->assertSame($extension, $bundle->getContainerExtension());
     }
 }


### PR DESCRIPTION
## Summary

Second of four scoped follow-ups to #44 killing surviving mutants to push the mutation score above 90%. This PR covers `src/ItkDevOpenIdConnectBundle.php` (5 escaped mutants).

## Features Added

* `testGetContainerExtension`: asserts `getContainerExtension()` returns an `ItkDevOpenIdConnectExtension` and that a second call returns the same instance. The memoization condition (`null === $this->extension || false === $this->extension`) previously had zero assertions against it, so all five of its mutants (operator flips, negations, `||`→`&&`) survived.

## Files Changed

* `tests/ItkDevOpenIdConnectBundleTest.php` - new memoization test
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 80 tests, 169 assertions, green
* `vendor/bin/infection --filter=src/ItkDevOpenIdConnectBundle.php` — 5/5 mutants killed (was 0/5)
* PHPStan max level + php-cs-fixer — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)