### PR TITLE
test: pin down CLI login token lifecycle and URL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dev: strengthened CLI login flow tests based on mutation testing
+  findings — redeeming an unknown token is asserted to throw
+  `TokenNotFoundException` specifically, both cache entries (token and
+  reverse username entry) are asserted removed after a token is used,
+  `encodeKey` asserts the exact namespaced encoding instead of only an
+  encode/decode roundtrip, and the CLI login URL is asserted to receive
+  the login token and route. No effect on the published package.
+
 - CI: bumped `codecov/codecov-action` from `v5` to `v7` (restores Codecov's
   GPG signing key after the `codecovsecurity` account was removed, and moves
   the bundled `github-script` to Node 24) and set `fail_ci_if_error: false`

--- a/tests/Command/UserLoginCommandTest.php
+++ b/tests/Command/UserLoginCommandTest.php
@@ -53,6 +53,29 @@ class UserLoginCommandTest extends TestCase
         $this->assertStringContainsString('https://app.com/login?loginToken=generated-token', $tester->getDisplay());
     }
 
+    public function testExecutePassesTokenAndRouteToUrlGenerator(): void
+    {
+        $this->stubCliLoginHelper
+            ->method('createToken')
+            ->willReturn('generated-token');
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('cli_login_route', ['loginToken' => 'generated-token'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://app.com/login?loginToken=generated-token');
+
+        $command = new UserLoginCommand(
+            $this->stubCliLoginHelper,
+            'cli_login_route',
+            $urlGenerator,
+            $this->stubUserProvider
+        );
+
+        $tester = new CommandTester($command);
+        $this->assertSame(Command::SUCCESS, $tester->execute(['username' => 'testuser']));
+    }
+
     public function testExecuteUserNotFound(): void
     {
         $this->stubUserProvider

--- a/tests/Command/UserLoginCommandTest.php
+++ b/tests/Command/UserLoginCommandTest.php
@@ -44,13 +44,13 @@ class UserLoginCommandTest extends TestCase
 
         $this->stubUrlGenerator
             ->method('generate')
-            ->willReturn('https://app.com/login?loginToken=generated-token');
+            ->willReturn('https://example.org/login?loginToken=generated-token');
 
         $tester = new CommandTester($this->command);
         $result = $tester->execute(['username' => 'testuser']);
 
         $this->assertSame(Command::SUCCESS, $result);
-        $this->assertStringContainsString('https://app.com/login?loginToken=generated-token', $tester->getDisplay());
+        $this->assertStringContainsString('https://example.org/login?loginToken=generated-token', $tester->getDisplay());
     }
 
     public function testExecutePassesTokenAndRouteToUrlGenerator(): void
@@ -63,7 +63,7 @@ class UserLoginCommandTest extends TestCase
         $urlGenerator->expects($this->once())
             ->method('generate')
             ->with('cli_login_route', ['loginToken' => 'generated-token'], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://app.com/login?loginToken=generated-token');
+            ->willReturn('https://example.org/login?loginToken=generated-token');
 
         $command = new UserLoginCommand(
             $this->stubCliLoginHelper,

--- a/tests/Command/UserLoginCommandTest.php
+++ b/tests/Command/UserLoginCommandTest.php
@@ -44,13 +44,13 @@ class UserLoginCommandTest extends TestCase
 
         $this->stubUrlGenerator
             ->method('generate')
-            ->willReturn('https://example.org/login?loginToken=generated-token');
+            ->willReturn('https://app.example.org/login?loginToken=generated-token');
 
         $tester = new CommandTester($this->command);
         $result = $tester->execute(['username' => 'testuser']);
 
         $this->assertSame(Command::SUCCESS, $result);
-        $this->assertStringContainsString('https://example.org/login?loginToken=generated-token', $tester->getDisplay());
+        $this->assertStringContainsString('https://app.example.org/login?loginToken=generated-token', $tester->getDisplay());
     }
 
     public function testExecutePassesTokenAndRouteToUrlGenerator(): void
@@ -63,7 +63,7 @@ class UserLoginCommandTest extends TestCase
         $urlGenerator->expects($this->once())
             ->method('generate')
             ->with('cli_login_route', ['loginToken' => 'generated-token'], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://example.org/login?loginToken=generated-token');
+            ->willReturn('https://app.example.org/login?loginToken=generated-token');
 
         $command = new UserLoginCommand(
             $this->stubCliLoginHelper,

--- a/tests/Util/CliLoginHelperTest.php
+++ b/tests/Util/CliLoginHelperTest.php
@@ -4,6 +4,7 @@ namespace ItkDev\OpenIdConnectBundle\Tests\Util;
 
 use ItkDev\OpenIdConnectBundle\Exception\CacheException;
 use ItkDev\OpenIdConnectBundle\Exception\OpenIdConnectBundleExceptionInterface;
+use ItkDev\OpenIdConnectBundle\Exception\TokenNotFoundException;
 use ItkDev\OpenIdConnectBundle\Util\CliLoginHelper;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
@@ -40,7 +41,10 @@ class CliLoginHelperTest extends TestCase
 
     public function testThrowExceptionIfTokenDoesNotExist(): void
     {
-        $this->expectException(OpenIdConnectBundleExceptionInterface::class);
+        // TokenNotFoundException (not just the marker interface) is part of
+        // the public contract: CliLoginTokenAuthenticator catches it
+        // specifically to distinguish "no such token" from cache failures.
+        $this->expectException(TokenNotFoundException::class);
 
         $cache = new ArrayAdapter();
 
@@ -77,6 +81,37 @@ class CliLoginHelperTest extends TestCase
         $this->expectException(OpenIdConnectBundleExceptionInterface::class);
 
         $cliHelper->getUsername($token);
+    }
+
+    public function testBothCacheEntriesAreRemovedAfterUse(): void
+    {
+        $cache = new ArrayAdapter();
+
+        $cliHelper = new CliLoginHelper($cache);
+
+        $testUser = 'test_user';
+        $token = $cliHelper->createToken($testUser);
+
+        $this->assertEquals($testUser, $cliHelper->getUsername($token));
+
+        // The reverse entry (username => token) must be gone too; otherwise
+        // createToken() would hand out the already-redeemed token again.
+        $this->assertFalse($cache->hasItem($cliHelper->encodeKey($testUser)));
+
+        $newToken = $cliHelper->createToken($testUser);
+        $this->assertNotSame($token, $newToken);
+        $this->assertEquals($testUser, $cliHelper->getUsername($newToken));
+    }
+
+    public function testEncodeKeyPrependsNamespace(): void
+    {
+        $cache = new ArrayAdapter();
+        $cliHelper = new CliLoginHelper($cache);
+
+        // Assert the exact encoding, not just an encode/decode roundtrip:
+        // the namespace prefix guards against cache key collisions with the
+        // consuming application, and a roundtrip is blind to losing it.
+        $this->assertSame(base64_encode('itk-dev-cli-logintest_user'), $cliHelper->encodeKey('test_user'));
     }
 
     public function testCreateTokenAndGetUsername(): void


### PR DESCRIPTION
## Summary

Third of four scoped follow-ups to #44 killing surviving mutants to push the mutation score above 90%. This PR covers the CLI login flow: `src/Util/CliLoginHelper.php` and `src/Command/UserLoginCommand.php` (5 escaped mutants, two of them security-adjacent).

## Features Added

* `testThrowExceptionIfTokenDoesNotExist` now expects `TokenNotFoundException` specifically — previously it caught the marker interface, so removing the throw still passed because the subsequent `CacheException` also matched
* `testBothCacheEntriesAreRemovedAfterUse`: asserts the reverse username→token entry is deleted on redemption (single-use guarantee), and that a fresh, redeemable token is minted afterwards
* `testEncodeKeyPrependsNamespace`: asserts the exact namespaced encoding — the existing encode/decode roundtrip is structurally blind to losing or reordering the cache-key collision guard
* `testExecutePassesTokenAndRouteToUrlGenerator`: mocks the URL generator with argument expectations, so dropping the `loginToken` parameter from the generated login URL now fails

## Files Changed

* `tests/Util/CliLoginHelperTest.php` - token lifecycle + encoding tests
* `tests/Command/UserLoginCommandTest.php` - URL generation argument expectations
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 82 tests, 177 assertions, green
* `vendor/bin/infection --filter=src/Util,src/Command` — 35/35 mutants killed (was 30/35)
* PHPStan max level + php-cs-fixer — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)