### PR TITLE
test: verify provider key lookup, claims contract and redirect route args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dev: strengthened Security tests based on mutation testing findings —
+  the redirect-route parameters are asserted to reach the router when
+  building a provider redirect URI, `validateClaims` is asserted to look
+  up the exact provider key from the session and to merge
+  `open_id_connect_provider` into the returned claims, and a request
+  without any `loginToken` parameter is asserted to be rejected as
+  unauthorized. No effect on the published package.
+
 - CI: bumped `codecov/codecov-action` from `v5` to `v7` (restores Codecov's
   GPG signing key after the `codecovsecurity` account was removed, and moves
   the bundled `github-script` to Node 24) and set `fail_ci_if_error: false`

--- a/tests/Security/CliLoginTokenAuthenticatorTest.php
+++ b/tests/Security/CliLoginTokenAuthenticatorTest.php
@@ -61,6 +61,19 @@ class CliLoginTokenAuthenticatorTest extends TestCase
         $this->authenticator->authenticate($request);
     }
 
+    public function testAuthenticateWithMissingToken(): void
+    {
+        // No loginToken query parameter at all: the null from query->get()
+        // must be coerced to '' and rejected as "no token provided", not
+        // passed on to the login helper.
+        $request = new Request();
+
+        $this->expectException(CustomUserMessageAuthenticationException::class);
+        $this->expectExceptionMessage('No login token provided');
+
+        $this->authenticator->authenticate($request);
+    }
+
     public function testAuthenticateWithInvalidToken(): void
     {
         $this->stubCliLoginHelper

--- a/tests/Security/OpenIdConfigurationProviderManagerTest.php
+++ b/tests/Security/OpenIdConfigurationProviderManagerTest.php
@@ -9,6 +9,7 @@ use ItkDev\OpenIdConnectBundle\Security\OpenIdConfigurationProviderManager;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 class OpenIdConfigurationProviderManagerTest extends TestCase
@@ -77,9 +78,14 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
 
     public function testGetProviderWithRedirectRoute(): void
     {
-        $this->stubRouter
+        // Expect the exact arguments so dropping the route parameters (or the
+        // route itself) when building the redirect URI fails the test.
+        $mockRouter = $this->createMock(RouterInterface::class);
+        $mockRouter->expects($this->once())
             ->method('generate')
+            ->with('my_route', ['param' => 'value'], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('https://app.com/callback');
+        $this->stubRouter = $mockRouter;
 
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [

--- a/tests/Security/OpenIdLoginAuthenticatorTest.php
+++ b/tests/Security/OpenIdLoginAuthenticatorTest.php
@@ -114,14 +114,26 @@ class OpenIdLoginAuthenticatorTest extends TestCase
         $claims->name = 'Test Tester';
         $stubProvider->method('validateIdToken')->willReturn($claims);
 
-        $this->stubProviderManager->method('getProvider')->willReturn($stubProvider);
+        // Expect the exact provider key from the session, so a lookup with a
+        // mangled key fails the test instead of silently matching any key.
+        $mockProviderManager = $this->createMock(OpenIdConfigurationProviderManager::class);
+        $mockProviderManager->expects($this->once())
+            ->method('getProvider')
+            ->with('test_provider_1')
+            ->willReturn($stubProvider);
+        $authenticator = new TestAuthenticator($mockProviderManager);
 
         $request = new Request(query: ['state' => 'test_state', 'code' => 'test_code']);
         $this->setSessionOnRequest($request);
 
-        $passport = $this->authenticator->authenticate($request);
+        $passport = $authenticator->authenticate($request);
 
         $this->assertSame('test@test.com', $passport->getUser()->getUserIdentifier());
+
+        // The claims contract: the IdP claims plus the provider key that
+        // authenticated the user.
+        $this->assertSame('Test Tester', $authenticator->lastClaims['name'] ?? null);
+        $this->assertSame('test_provider_1', $authenticator->lastClaims['open_id_connect_provider'] ?? null);
     }
 
     private function setSessionOnRequest(Request $request, ?string $nonce = 'test_nonce'): void

--- a/tests/Security/TestAuthenticator.php
+++ b/tests/Security/TestAuthenticator.php
@@ -13,9 +13,18 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 
 class TestAuthenticator extends OpenIdLoginAuthenticator
 {
+    /**
+     * Claims returned by the last validateClaims() call, exposed so tests
+     * can assert on the full claims array (validateClaims is protected).
+     *
+     * @var array<string, string>
+     */
+    public array $lastClaims = [];
+
     public function authenticate(Request $request): Passport
     {
         $claims = $this->validateClaims($request);
+        $this->lastClaims = $claims;
 
         return new SelfValidatingPassport(
             new UserBadge(


### PR DESCRIPTION
## Summary

Last of four scoped follow-ups to #44 killing surviving mutants to push the mutation score above 90%. This PR covers `src/Security` (4 escaped mutants).

## Features Added

* `OpenIdConfigurationProviderManagerTest`: the redirect-route test now mocks the router with exact argument expectations (`route`, `redirect_route_parameters`, `ABSOLUTE_URL`) — previously a stub ignored its arguments, so the parameters could be dropped undetected
* `OpenIdLoginAuthenticatorTest`: the success path now expects `getProvider()` to be called with the exact provider key from the session, and asserts the returned claims contain both the IdP claims and `open_id_connect_provider` (the documented claims contract)
* `TestAuthenticator` fixture exposes the last validated claims so tests can assert on the full array (`validateClaims` is protected)
* `CliLoginTokenAuthenticatorTest`: new test for a request with no `loginToken` parameter at all — the null must be coerced and rejected as unauthorized, not passed to the login helper (only the empty-string case was covered)

## Files Changed

* `tests/Security/OpenIdConfigurationProviderManagerTest.php` - router argument expectations
* `tests/Security/OpenIdLoginAuthenticatorTest.php` - provider key + claims contract assertions
* `tests/Security/TestAuthenticator.php` - expose last claims for assertions
* `tests/Security/CliLoginTokenAuthenticatorTest.php` - missing-token test
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 80 tests, 177 assertions, green
* `vendor/bin/infection --filter=src/Security` — 48/48 mutants killed (was 44/48)
* PHPStan max level + php-cs-fixer — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)