### PR TITLE
test: use RFC 2606 reserved domains in all test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dev: test fixtures use RFC 2606 reserved domains only —
+  `provider.example.org` for IdP-side URLs (metadata, authorization) and
+  `app.example.org` for application-side URLs (redirect/callback, CLI
+  login), replacing real registrable domains (`app.com`, `provider.com`,
+  `other.com`, `test.com`). No effect on the published package.
 - Dev: added a test for `ItkDevOpenIdConnectBundle::getContainerExtension()`
   asserting the custom extension is created and memoized (same instance on
   repeated calls), prompted by mutation testing findings. No effect on the

--- a/tests/Command/UserLoginCommandTest.php
+++ b/tests/Command/UserLoginCommandTest.php
@@ -44,13 +44,13 @@ class UserLoginCommandTest extends TestCase
 
         $this->stubUrlGenerator
             ->method('generate')
-            ->willReturn('https://app.com/login?loginToken=generated-token');
+            ->willReturn('https://app.example.org/login?loginToken=generated-token');
 
         $tester = new CommandTester($this->command);
         $result = $tester->execute(['username' => 'testuser']);
 
         $this->assertSame(Command::SUCCESS, $result);
-        $this->assertStringContainsString('https://app.com/login?loginToken=generated-token', $tester->getDisplay());
+        $this->assertStringContainsString('https://app.example.org/login?loginToken=generated-token', $tester->getDisplay());
     }
 
     public function testExecuteUserNotFound(): void

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -33,7 +33,7 @@ class LoginControllerTest extends TestCase
             ->expects($this->exactly(1))
             ->method('getAuthorizationUrl')
             ->with(['state' => 'abcd', 'nonce' => '1234', 'response_type' => 'code', 'scope' => 'openid email profile'])
-            ->willReturn('https://test.com');
+            ->willReturn('https://provider.example.org/authorize');
 
         $controller = $this->createController($mockProvider);
 
@@ -58,7 +58,7 @@ class LoginControllerTest extends TestCase
             });
 
         $response = $controller->login($request, $mockSession, 'test');
-        $this->assertSame('https://test.com', $response->getTargetUrl());
+        $this->assertSame('https://provider.example.org/authorize', $response->getTargetUrl());
     }
 
     public function testUnknownProviderKeyMapsTo404(): void

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -66,7 +66,7 @@ class ConfigurationTest extends TestCase
         $input['user_provider'] = 'my_user_provider';
         $input['openid_providers']['provider1']['options']['leeway'] = 30;
         $input['openid_providers']['provider1']['options']['cache_duration'] = 3600;
-        $input['openid_providers']['provider1']['options']['redirect_uri'] = 'https://app.com/callback';
+        $input['openid_providers']['provider1']['options']['redirect_uri'] = 'https://app.example.org/callback';
         $input['openid_providers']['provider1']['options']['allow_http'] = true;
 
         $config = $this->processor->processConfiguration(
@@ -79,7 +79,7 @@ class ConfigurationTest extends TestCase
         $provider = $config['openid_providers']['provider1']['options'];
         $this->assertSame(30, $provider['leeway']);
         $this->assertSame(3600, $provider['cache_duration']);
-        $this->assertSame('https://app.com/callback', $provider['redirect_uri']);
+        $this->assertSame('https://app.example.org/callback', $provider['redirect_uri']);
         $this->assertTrue($provider['allow_http']);
     }
 
@@ -100,7 +100,7 @@ class ConfigurationTest extends TestCase
     public function testBothRedirectUriAndRouteThrows(): void
     {
         $input = $this->getMinimalConfig();
-        $input['openid_providers']['provider1']['options']['redirect_uri'] = 'https://app.com/callback';
+        $input['openid_providers']['provider1']['options']['redirect_uri'] = 'https://app.example.org/callback';
         $input['openid_providers']['provider1']['options']['redirect_route'] = 'my_route';
 
         $this->expectException(InvalidConfigurationException::class);
@@ -186,7 +186,7 @@ class ConfigurationTest extends TestCase
         $input = $this->getMinimalConfig();
         $input['openid_providers']['provider2'] = [
             'options' => [
-                'metadata_url' => 'https://other.com/.well-known/openid-configuration',
+                'metadata_url' => 'https://other-provider.example.org/.well-known/openid-configuration',
                 'client_id' => 'other_id',
                 'client_secret' => 'other_secret',
             ],

--- a/tests/Security/OpenIdConfigurationProviderManagerTest.php
+++ b/tests/Security/OpenIdConfigurationProviderManagerTest.php
@@ -79,7 +79,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $this->stubRouter
             ->method('generate')
-            ->willReturn('https://app.com/callback');
+            ->willReturn('https://app.example.org/callback');
 
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
@@ -96,7 +96,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $this->stubRouter
             ->method('generate')
-            ->willReturn('https://app.com/callback');
+            ->willReturn('https://app.example.org/callback');
 
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
@@ -112,7 +112,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
-                'redirect_uri' => 'https://app.com/callback',
+                'redirect_uri' => 'https://app.example.org/callback',
                 'leeway' => 30,
             ],
         ]);
@@ -125,7 +125,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
-                'redirect_uri' => 'https://app.com/callback',
+                'redirect_uri' => 'https://app.example.org/callback',
                 'cache_duration' => 3600,
             ],
         ]);
@@ -138,7 +138,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
-                'redirect_uri' => 'https://app.com/callback',
+                'redirect_uri' => 'https://app.example.org/callback',
                 'allow_http' => true,
             ],
         ]);
@@ -166,7 +166,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
-                'redirect_uri' => 'https://app.com/callback',
+                'redirect_uri' => 'https://app.example.org/callback',
                 'http_client_options' => [
                     'timeout' => 1.5,
                     'proxy' => 'http://proxy:8080',
@@ -189,7 +189,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
-                'redirect_uri' => 'https://app.com/callback',
+                'redirect_uri' => 'https://app.example.org/callback',
             ],
         ]);
 
@@ -205,7 +205,7 @@ class OpenIdConfigurationProviderManagerTest extends TestCase
     {
         $manager = $this->createManager([
             'test' => $this->getBaseProviderConfig() + [
-                'redirect_uri' => 'https://app.com/callback',
+                'redirect_uri' => 'https://app.example.org/callback',
             ],
         ]);
 

--- a/tests/Security/OpenIdLoginAuthenticatorTest.php
+++ b/tests/Security/OpenIdLoginAuthenticatorTest.php
@@ -110,7 +110,7 @@ class OpenIdLoginAuthenticatorTest extends TestCase
         $stubProvider = $this->createStub(OpenIdConfigurationProvider::class);
 
         $claims = new \stdClass();
-        $claims->email = 'test@test.com';
+        $claims->email = 'test@example.org';
         $claims->name = 'Test Tester';
         $stubProvider->method('validateIdToken')->willReturn($claims);
 
@@ -121,7 +121,7 @@ class OpenIdLoginAuthenticatorTest extends TestCase
 
         $passport = $this->authenticator->authenticate($request);
 
-        $this->assertSame('test@test.com', $passport->getUser()->getUserIdentifier());
+        $this->assertSame('test@example.org', $passport->getUser()->getUserIdentifier());
     }
 
     private function setSessionOnRequest(Request $request, ?string $nonce = 'test_nonce'): void

--- a/tests/config/itkdev_openid_connect.yml
+++ b/tests/config/itkdev_openid_connect.yml
@@ -7,14 +7,14 @@ itkdev_openid_connect:
   openid_providers:
     test_provider_1:
       options:
-        metadata_url: "https://provider.com/openid-configuration"
+        metadata_url: "https://provider.example.org/openid-configuration"
         client_id: "test_id"
         client_secret: "test_secret"
-        redirect_uri: "https://app.com/callback_uri"
+        redirect_uri: "https://app.example.org/callback_uri"
     test_provider_2:
       options:
-        metadata_url: "https://provider.com/openid-configuration"
+        metadata_url: "https://provider.example.org/openid-configuration"
         client_id: "test_id"
         leeway: 5
         client_secret: "test_secret"
-        redirect_uri: "https://app.com/callback_uri"
+        redirect_uri: "https://app.example.org/callback_uri"


### PR DESCRIPTION
## Summary

Replaces every invented-but-registrable domain in the test fixtures with [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) reserved names, using subdomains for readability:

* `provider.example.org` — IdP-side URLs (`metadata_url`, authorization endpoint); a second provider in the multi-provider test uses `other-provider.example.org`
* `app.example.org` — application-side URLs (`redirect_uri`/callbacks, CLI login page)
* `test@example.org` — test account email

Domains removed: `app.com` (13×), `provider.com` (2×), `other.com`, `test.com` (incl. `test@test.com`).

## Files Changed

* `tests/config/itkdev_openid_connect.yml` - provider metadata + redirect URIs
* `tests/Security/OpenIdConfigurationProviderManagerTest.php` - callback URIs
* `tests/Security/OpenIdLoginAuthenticatorTest.php` - test email
* `tests/DependencyInjection/ConfigurationTest.php` - redirect URIs + second provider metadata URL
* `tests/Controller/LoginControllerTest.php` - IdP authorization URL
* `tests/Command/UserLoginCommandTest.php` - CLI login URL (same change as #47; identical on both sides, so merges cleanly in either order)
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 83 tests, 184 assertions, green
* PHPStan max level, markdownlint, prettier (yaml) — clean
* `grep -rE 'app\.com|provider\.com|other\.com|test\.com' tests/ src/ README.md` — no matches

## Notes

* Pre-existing `example.com` metadata URLs (already RFC 2606-compliant) were left unchanged
* Overlaps with open PRs #47/#48 on three test files; identical or trivially resolvable — I'll resolve any conflicts as they merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)