### PR TITLE
ci: name the PHP version and dependency set in the mutation-tests job

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -87,8 +87,14 @@ jobs:
           flags: unittests
 
   mutation-tests:
-    name: Mutation tests
+    name: Mutation tests (${{ matrix.php }}, ${{ matrix.prefer }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: phpfpm
+            php: "8.3"
+            prefer: prefer-stable
     steps:
       - uses: actions/checkout@v6
 
@@ -106,7 +112,7 @@ jobs:
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
         run: |
-          docker compose run --rm phpfpm composer install
+          docker compose run --rm ${{ matrix.service }} composer install
           docker compose run --rm \
             -e XDEBUG_MODE=coverage \
             -e GITHUB_ACTIONS \
@@ -118,4 +124,4 @@ jobs:
             -e GITHUB_RUN_ID \
             -e GITHUB_SERVER_URL \
             -e STRYKER_DASHBOARD_API_KEY \
-            phpfpm vendor/bin/infection --logger-github
+            ${{ matrix.service }} vendor/bin/infection --logger-github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI: the mutation-tests job declares its PHP version and dependency set
+  via a single-entry matrix (`Mutation tests (8.3, prefer-stable)`), so
+  the job name makes explicit what mutation testing runs on. No effect on
+  the published package.
 - Dev: strengthened CLI login flow tests based on mutation testing
   findings — redeeming an unknown token is asserted to throw
   `TokenNotFoundException` specifically, both cache entries (token and


### PR DESCRIPTION
## Summary

The `mutation-tests` job ran on the default `phpfpm` service without saying which PHP version that is. It now declares PHP version and dependency set via a single-entry matrix, mirroring the unit-tests job, so the check name reads **Mutation tests (8.3, prefer-stable)** in the PR checks list.

## Files Changed

* `.github/workflows/php.yaml` - single-entry matrix (`service`/`php`/`prefer`) on the mutation-tests job; the compose service is selected via `${{ matrix.service }}` instead of being hard-coded
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* The renamed check on this PR should appear as `Mutation tests (8.3, prefer-stable)` and pass
* prettier (yaml) + markdownlint — clean

## Notes

* Branch protection/required checks: if `Mutation tests` is ever added as a required status check by its old name, the rename must be reflected there
* Extending mutation testing to more PHP versions later is now a one-line matrix addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)