### PR TITLE
ci: raise minimum mutation score to 95 and condense changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,49 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Dev: mutation testing with [Infection](https://infection.github.io/)
-  (`task test:mutation`). The minimum mutation score is configured in
-  `infection.json5` and enforced in CI; escaped mutants are annotated inline
-  on pull requests, and results for `develop` are published to the Stryker
-  dashboard (mutation score badge in the README). No effect on the published
-  package.
+- Mutation testing with [Infection](https://infection.github.io/)
+  (`task test:mutation`), run in CI and reported to the Stryker dashboard
+  (mutation score badge in README)
 
 ### Changed
 
-- CI: the mutation-tests job declares its PHP version and dependency set
-  via a single-entry matrix (`Mutation tests (8.3, prefer-stable)`), so
-  the job name makes explicit what mutation testing runs on. No effect on
-  the published package.
-- Dev: test fixtures use RFC 2606 reserved domains only —
-  `provider.example.org` for IdP-side URLs (metadata, authorization) and
-  `app.example.org` for application-side URLs (redirect/callback, CLI
-  login), replacing real registrable domains (`app.com`, `provider.com`,
-  `other.com`, `test.com`). No effect on the published package.
-- Dev: strengthened Security tests based on mutation testing findings —
-  the redirect-route parameters are asserted to reach the router when
-  building a provider redirect URI, `validateClaims` is asserted to look
-  up the exact provider key from the session and to merge
-  `open_id_connect_provider` into the returned claims, and a request
-  without any `loginToken` parameter is asserted to be rejected as
-  unauthorized. No effect on the published package.
-- Dev: strengthened CLI login flow tests based on mutation testing
-  findings — redeeming an unknown token is asserted to throw
-  `TokenNotFoundException` specifically, both cache entries (token and
-  reverse username entry) are asserted removed after a token is used,
-  `encodeKey` asserts the exact namespaced encoding instead of only an
-  encode/decode roundtrip, and the CLI login URL is asserted to receive
-  the login token and route. No effect on the published package.
-- Dev: added a test for `ItkDevOpenIdConnectBundle::getContainerExtension()`
-  asserting the custom extension is created and memoized (same instance on
-  repeated calls), prompted by mutation testing findings. No effect on the
-  published package.
-- Dev: strengthened DependencyInjection tests based on mutation testing
-  findings — the extension's container wiring (cache pool reference,
-  provider options mapping, CLI login route arguments) is now asserted
-  explicitly, and the documented invariant that provider keys are not
-  normalized (`my-provider` ≠ `my_provider`) is covered by a test. No
-  effect on the published package.
-
+- Strengthened tests guided by mutation testing; mutation score raised to
+  100% with a CI threshold of 95 (`minCoveredMsi` in `infection.json5`)
+- Test fixtures use RFC 2606 reserved domains (`provider.example.org`,
+  `app.example.org`) instead of registrable domains
 - CI: bumped `codecov/codecov-action` from `v5` to `v7` (restores Codecov's
   GPG signing key after the `codecovsecurity` account was removed, and moves
   the bundled `github-script` to Node 24) and set `fail_ci_if_error: false`

--- a/infection.json5
+++ b/infection.json5
@@ -5,8 +5,9 @@
     },
     "threads": "max",
     // Minimum mutation score for covered code; enforced locally and in CI.
-    // Baseline measured at 80% — ratchet up as surviving mutants are killed.
-    "minCoveredMsi": 78,
+    // The suite currently kills all mutants (100%); 95 leaves headroom for
+    // run-to-run variance without letting real test-quality erosion through.
+    "minCoveredMsi": 95,
     "logs": {
         "text": "infection.log",
         "html": "infection.html",


### PR DESCRIPTION
## Summary

Follow-up to the mutation-testing rollout (#44–#50): the test suite now kills all 115 mutants (100% covered MSI), so the bootstrap threshold of 78 is ratcheted up to 95 — high enough to defend the score, with headroom for run-to-run variance.

The `[Unreleased]` changelog is also condensed: the six per-PR bullets describing intermediate test-strengthening steps are collapsed into two final-outcome entries (mutation testing added; tests strengthened to 100% score), matching the concise tone of earlier releases. In-flight details remain available in PR/commit history.

## Files Changed

* `infection.json5` - `minCoveredMsi` 78 → 95, comment updated
* `CHANGELOG.md` - condensed Unreleased entries

## Test Plan

* `task test:mutation` — 115/115 mutants killed, 100% covered MSI, passes the new 95 threshold
* markdownlint — clean
* The `Mutation tests (8.3, prefer-stable)` check on this PR exercises the new threshold in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)