### PR TITLE
fix: preserve authentication failure cause in onAuthenticationFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `OpenIdLoginAuthenticator::onAuthenticationFailure()` now chains the
+  original exception via `previous` and includes its message, so logs and
+  error reporters retain the cause (timeout vs. signature mismatch vs.
+  wrong nonce). Symfony's security component still renders only the safe
+  message key to the user.
 - Strengthened tests guided by mutation testing; mutation score raised to
   100% with a CI threshold of 95 (`minCoveredMsi` in `infection.json5`)
 - Test fixtures use RFC 2606 reserved domains (`provider.example.org`,

--- a/src/Security/OpenIdLoginAuthenticator.php
+++ b/src/Security/OpenIdLoginAuthenticator.php
@@ -78,6 +78,9 @@ abstract class OpenIdLoginAuthenticator extends AbstractAuthenticator implements
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
-        throw new AuthenticationException('Error occurred validating openid login');
+        // Preserve the cause so logs and error reporters can see what actually
+        // failed (timeout, signature mismatch, wrong nonce, etc.). Symfony's
+        // security component renders only the safe message key to the user.
+        throw new AuthenticationException(sprintf('Error occurred validating openid login: %s', $exception->getMessage()), $exception->getCode(), $exception);
     }
 }

--- a/tests/Security/OpenIdLoginAuthenticatorTest.php
+++ b/tests/Security/OpenIdLoginAuthenticatorTest.php
@@ -40,13 +40,17 @@ class OpenIdLoginAuthenticatorTest extends TestCase
         $this->assertTrue($this->authenticator->supports($request));
     }
 
-    public function testOnAuthenticationFailure(): void
+    public function testOnAuthenticationFailurePreservesCause(): void
     {
-        $this->expectException(AuthenticationException::class);
+        $cause = new AuthenticationException('Original cause message');
 
-        $exception = new AuthenticationException();
-
-        $this->authenticator->onAuthenticationFailure(new Request(), $exception);
+        try {
+            $this->authenticator->onAuthenticationFailure(new Request(), $cause);
+            $this->fail('Expected AuthenticationException');
+        } catch (AuthenticationException $thrown) {
+            $this->assertSame($cause, $thrown->getPrevious(), 'Original exception must be chained as previous');
+            $this->assertStringContainsString('Original cause message', $thrown->getMessage(), 'Cause message must be preserved for logs');
+        }
     }
 
     public function testValidateClaimsWrongState(): void


### PR DESCRIPTION
## Summary

`OpenIdLoginAuthenticator::onAuthenticationFailure()` previously threw a bare `AuthenticationException('Error occurred validating openid login')`, dropping the original failure entirely — logs and error reporters could not tell a timeout from a signature mismatch from a wrong nonce.

It now chains the original exception via `previous` and includes its message in the new exception's message. Symfony's security component still renders only the safe message key to the user, so nothing sensitive is exposed.

This is the last unmerged piece of `feature/exception-flow` (commit 222bf32), ported onto current develop; the rest of that branch was superseded by the 5.0 exception-contract work (#41 et al.), and the branch is deleted with this PR.

## Files Changed

* `src/Security/OpenIdLoginAuthenticator.php` - chain `previous` and preserve the cause message in `onAuthenticationFailure()`
* `tests/Security/OpenIdLoginAuthenticatorTest.php` - assert the thrown exception chains the original as `previous` and preserves its message
* `CHANGELOG.md` - entry under `[Unreleased]` / Changed

## Test Plan

* `task test:coverage` — all tests pass, coverage stays at 100% (methods + lines)
* `task analyze:php` — PHPStan max level + custom exception-contract rules: no errors (the new throw satisfies `WrappedExceptionChainsPrevious`)
* `task lint` — php-cs-fixer, composer normalize/audit, markdownlint, prettier: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)